### PR TITLE
fix:レビューがない場合の表示を修正

### DIFF
--- a/app/views/shops/_latest_reviews.html.erb
+++ b/app/views/shops/_latest_reviews.html.erb
@@ -1,9 +1,15 @@
 <div class="card w-full bg-white">
   <div class="card-body p-4">
     <h2 class="card-title">レビュー</h2>
-    <%= render partial:'shops/review', collection: reviews %>
-    <div class="card-actions justify-center mt-4">
-      <%= link_to t('.show_all_reviews'), shop_reviews_path(shop), class: 'btn' %>
-    </div>
+    <% if shop.reviews.present? %>
+      <%= render partial:'shops/review', collection: reviews %>
+      <div class="card-actions justify-center mt-4">
+        <%= link_to t('.show_all_reviews'), shop_reviews_path(shop), class: 'btn' %>
+      </div>
+    <% else %>
+      <div class="no_reviews text-center">
+        <p>まだレビューはありません。</p>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
レビューがない場合"すべてのレビューを見る"ボタンの代わりに"レビューはまだありません。"という文字列が表示されるように修正。

closes #82 