### PR TITLE
店舗一覧と詳細を調整

### DIFF
--- a/app/views/shared/_review_button.html.erb
+++ b/app/views/shared/_review_button.html.erb
@@ -1,5 +1,5 @@
       <% if logged_in? && current_user.reviewed?(shop) %>
-        <%= link_to t('defaults.show_my_review'), review_path(shop.reviews.find_by(user_id: current_user.id)), class: 'btn btn-primary', data: { turbo: false } %>
+        <%= link_to simple_format(t('defaults.show_my_review')), review_path(shop.reviews.find_by(user_id: current_user.id)), class: 'btn btn-primary', data: { turbo: false } %>
       <% else %>
         <%= link_to t('defaults.post_review'), new_shop_review_path(shop), class: 'btn btn-accent', data: { turbo: false } %>
       <% end %>

--- a/app/views/shops/_rating_field_for_shop.html.erb
+++ b/app/views/shops/_rating_field_for_shop.html.erb
@@ -1,4 +1,4 @@
-<div class="text-sm">
+<div class="text-sm text-right">
   <p>
     <%= Shop.human_attribute_name(field) + ': ' %>
     <% if shop.send("#{field}") == 0 %>

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -1,40 +1,59 @@
-<div class="card bg-neutral mx-auto w-full my-6">
-  <div class="card-body">
-    <h2 class="card-title">
-      <%= shop.name %>
-    </h2>
-
-    <div class="area">
-      <%= shop.area.name %> 
-    </div>
-
-    <div class="tags">
-      <% shop.tags.each do |tag| %>
-        <div class="badge badge-secondary badge-sm">
-          <%= tag.name %>
+<%= link_to shop_path(shop), data: {turbo: false} do %>
+  <div class="card bg-neutral mx-auto w-full my-6 active:bg-base-200 shadow-xl">
+    <div class="card-body p-6">
+      <% if current_page?(shop_path(shop)) %>
+        <div class="area text-xs text-right">
+          <%= shop.area.name %>
         </div>
       <% end %>
-      <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'link link-success text-xs', data: { turbo: false } %>
-    </div>
 
-    <div class="rating_averages gap-y-1">
-      <%= render 'rating_field_for_shop', shop: shop, field: :int_average %>
-      <%= render 'rating_field_for_shop', shop: shop, field: :eqcust_average %>
-      <%= render 'rating_field_for_shop', shop: shop, field: :sofr_average %>
-    </div>
+      <h2 class="card-title text-base">
+        <%= shop.name %>
+      </h2>
 
-    <div class="static-informations space-y-4 mt-4 text-sm">
-      <% %i[address phone_number url opening_hours].each do |key| %>
+
+      <div class="tags">
+        <% shop.tags.each do |tag| %>
+          <div class="badge badge-secondary badge-sm">
+            <%= tag.name %>
+          </div>
+        <% end %>
+        <% if current_page?(shop_path(shop)) %>
+          <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'link link-success text-xs', data: { turbo: false } %>
+        <% end %>
+      </div>
+
+      <div class="rating_averages gap-y-1 mt-4">
+        <%= render 'rating_field_for_shop', shop: shop, field: :int_average %>
+        <%= render 'rating_field_for_shop', shop: shop, field: :eqcust_average %>
+        <%= render 'rating_field_for_shop', shop: shop, field: :sofr_average %>
+      </div>
+
+      <div class="static-informations space-y-4 mt-4 text-sm">
         <div class="attribute">
           <p>
-            <%= Shop.human_attribute_name(key) + ':' %>
+            <%= Shop.human_attribute_name(:address) + ':' %>
             <br>
-            <%= simple_format(shop.send("#{key}")) %>
+            <%= simple_format(shop.address) %>
           </p>
         </div>
+
+        <% if current_page?(shop_path(shop)) %>
+          <% %i[phone_number opening_hours].each do |key| %>
+            <div class="attribute">
+              <p>
+                <%= Shop.human_attribute_name(key) + ':' %>
+                <br>
+                <%= simple_format(shop.send("#{key}")) %>
+              </p>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <% if current_page?(shop_path(shop)) %>
+        <%= render 'shop_buttons', shop: shop %>
       <% end %>
     </div>
-
-    <%= render 'shop_buttons', shop: shop %>
   </div>
-</div>
+<% end %>

--- a/app/views/shops/_shop_buttons.html.erb
+++ b/app/views/shops/_shop_buttons.html.erb
@@ -1,7 +1,4 @@
-<div class="card-actions justify-end mt-4">
-  <% if current_page?(shops_path) %>
-    <%= link_to t('defaults.show'), shop_path(shop), class: 'btn', data: { turbo: false } %>
-    <%= link_to t('defaults.reviews'), shop_reviews_path(shop), class: 'btn btn-primary', data: { turbo: false } %>
-  <% end %>
+<div class="card-actions justify-center mt-4">
+  <%= link_to t('defaults.to_official_site'), shop.url, class: 'btn btn-primary', target: '_blank' %>
   <%= render 'shared/review_button', shop: shop %>
 </div>

--- a/app/views/shops/_shop_for_index.html.erb
+++ b/app/views/shops/_shop_for_index.html.erb
@@ -1,25 +1,15 @@
 <%= link_to shop_path(shop), data: {turbo: false} do %>
-  <div class="card bg-neutral mx-auto w-full my-6 active:bg-base-200 shadow-xl">
+  <div class="card bg-neutral mx-auto w-full my-6 shadow-xl active:bg-base-200">
     <div class="card-body p-6">
-      <% if current_page?(shop_path(shop)) %>
-        <div class="area text-xs text-right">
-          <%= shop.area.name %>
-        </div>
-      <% end %>
-
       <h2 class="card-title text-base">
         <%= shop.name %>
       </h2>
-
 
       <div class="tags">
         <% shop.tags.each do |tag| %>
           <div class="badge badge-secondary badge-sm">
             <%= tag.name %>
           </div>
-        <% end %>
-        <% if current_page?(shop_path(shop)) %>
-          <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'link link-success text-xs', data: { turbo: false } %>
         <% end %>
       </div>
 
@@ -37,23 +27,7 @@
             <%= simple_format(shop.address) %>
           </p>
         </div>
-
-        <% if current_page?(shop_path(shop)) %>
-          <% %i[phone_number opening_hours].each do |key| %>
-            <div class="attribute">
-              <p>
-                <%= Shop.human_attribute_name(key) + ':' %>
-                <br>
-                <%= simple_format(shop.send("#{key}")) %>
-              </p>
-            </div>
-          <% end %>
-        <% end %>
       </div>
-
-      <% if current_page?(shop_path(shop)) %>
-        <%= render 'shop_buttons', shop: shop %>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/shops/_shop_for_show.html.erb
+++ b/app/views/shops/_shop_for_show.html.erb
@@ -1,0 +1,54 @@
+<div class="card bg-neutral mx-auto w-full my-6 shadow-xl">
+  <div class="card-body p-6">
+    <div class="area text-xs text-right">
+      <%= shop.area.name %>
+    </div>
+
+    <h2 class="card-title text-base">
+      <%= shop.name %>
+    </h2>
+
+    <div class="tags">
+      <% shop.tags.each do |tag| %>
+        <div class="badge badge-secondary badge-sm">
+          <%= tag.name %>
+        </div>
+      <% end %>
+      <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'link link-success text-xs', data: { turbo: false } %>
+    </div>
+
+    <div class="rating_averages gap-y-1 mt-4">
+      <%= render 'rating_field_for_shop', shop: shop, field: :int_average %>
+      <%= render 'rating_field_for_shop', shop: shop, field: :eqcust_average %>
+      <%= render 'rating_field_for_shop', shop: shop, field: :sofr_average %>
+    </div>
+
+    <div class="static-informations space-y-4 mt-4 text-sm">
+      <div class="attribute">
+        <p>
+          <%= Shop.human_attribute_name(:address) + ':' %>
+          <br>
+          <%= simple_format(shop.address) %>
+        </p>
+      </div>
+
+      <div class="attribute">
+        <p>
+          <%= Shop.human_attribute_name(:phone_number) + ':' %>
+          <br>
+          <%= link_to shop.phone_number, "tel:#{shop.phone_number}", class: 'link md:pointer-events-none md:no-underline' %>
+        </p>
+      </div>
+
+      <div class="attribute">
+        <p>
+          <%= Shop.human_attribute_name(:opening_hours) + ':' %>
+          <br>
+          <%= simple_format(shop.opening_hours) %>
+        </p>
+      </div>
+    </div>
+
+    <%= render 'shop_buttons', shop: shop %>
+  </div>
+</div>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= turbo_frame_tag 'shops-list' do %>
   <% if @shops.present? %>
-    <%= render @shops %>
+    <%= render partial: 'shop_for_index', collection: @shops, as: :shop %>
   <% else %>
     <p class="text-center"><%= t '.no_shops' %></p>
   <% end %>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,4 +1,4 @@
-<%= render @shop %>
+<%= render 'shop_for_show', shop: @shop %>
 
 <%= render 'latest_reviews', shop: @shop, reviews: @reviews %>
 

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -111,11 +111,12 @@ ja:
     reviews: レビュー一覧
     search_words: 検索ワード
     unspecified: 指定なし
+    to_official_site: 公式サイトへ
     terms: 利用規約
     privacy_policy: プライバシーポリシー
     contact: お問い合わせ
     post_review: レビューする
-    show_my_review: 投稿したレビューを見る
+    show_my_review: "投稿した\nレビューを見る"
     back: 戻る
     edit_tags: タグを編集
     delete_confirm: 削除しますか？


### PR DESCRIPTION
- 店舗一覧の情報量を減らし、カード自体をクリックして詳細に飛ぶように変更
- その一環で店舗一覧と詳細でパーシャルを別に
- 店舗詳細では画面がスマホサイズの場合のみ電話番号タップで電話をかけられるように変更

closes #143 