### PR TITLE
レーティング項目の説明を追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link href="https://use.fontawesome.com/releases/v6.5.1/css/all.css" rel="stylesheet">
   </head>
 
   <body class="flex flex-col min-h-screen">

--- a/app/views/my_reviews/_review.html.erb
+++ b/app/views/my_reviews/_review.html.erb
@@ -10,9 +10,9 @@
     <div class="divider mt-0"></div>
 
     <div class="review_body space-y-4">
-      <%= render 'reviews/rating_field_for_show', field: :minimal_interaction, review: review, field_short: 'int' %>
-      <%= render 'reviews/rating_field_for_show', field: :equipment_customization, review: review, field_short: 'eqcust' %>
-      <%= render 'reviews/rating_field_for_show', field: :solo_friendly, review: review, field_short: 'sofr' %>
+      <%= render 'reviews/rating_field_for_show', field: :minimal_interaction, review: review, field_short: 'int', description: t('defaults.desc_of_int') %>
+      <%= render 'reviews/rating_field_for_show', field: :equipment_customization, review: review, field_short: 'eqcust', description: t('defaults.desc_of_eqcust') %>
+      <%= render 'reviews/rating_field_for_show', field: :solo_friendly, review: review, field_short: 'sofr', description: t('defaults.desc_of_sofr') %>
 
       <div class="comment space-y-1">
         <div class="attribure_name">

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with(model: review.persisted? ? review : [shop, review], class: "contents") do |form| %>
   <%= render 'shared/error_messages', object: form.object %>
 
-  <%= render 'rating_field_for_form', form: form, field: :minimal_interaction, field_short: 'int' %>
-  <%= render 'rating_field_for_form', form: form, field: :equipment_customization, field_short: 'eqcust' %>
-  <%= render 'rating_field_for_form', form: form, field: :solo_friendly, field_short: 'sofr' %>
+  <%= render 'rating_field_for_form', form: form, field: :minimal_interaction, field_short: 'int', description: t('defaults.desc_of_int') %>
+  <%= render 'rating_field_for_form', form: form, field: :equipment_customization, field_short: 'eqcust', description: t('defaults.desc_of_eqcust') %>
+  <%= render 'rating_field_for_form', form: form, field: :solo_friendly, field_short: 'sofr', description: t('defaults.desc_of_sofr') %>
 
   <div class="my-5 flex flex-col">
     <%= form.label :comment, class: 'block my-2' %>

--- a/app/views/reviews/_rating_field_for_form.html.erb
+++ b/app/views/reviews/_rating_field_for_form.html.erb
@@ -1,5 +1,10 @@
 <div class="my-5 flex flex-col">
-  <%= form.label field, class: 'block my-2' %>
+  <div class="label flex justify-start">
+    <%= form.label field %>
+    <div class="tooltip tooltip-info inline-block ml-2" data-tip="<%= description %>">
+      <i class="fa-regular fa-circle-question fa-sm" style="color: #5eead4;"></i>
+    </div>
+  </div>
   <div class="rating">
     <%= form.radio_button field, "#{field}_unspecified", class: 'rating-hidden' %>
     <% Review.send("#{field_short}_rates").each do |rate| %>

--- a/app/views/reviews/_rating_field_for_show.html.erb
+++ b/app/views/reviews/_rating_field_for_show.html.erb
@@ -1,7 +1,12 @@
 <div class="space-y-1">
-  <p>
-    <%= Review.human_attribute_name(field) + ': ' %>
-  </p>
+  <div class="label flex justify-start p-0">
+    <div class="inline-block">
+      <%= Review.human_attribute_name(field) %>
+    </div>
+    <div class="tooltip tooltip-info inline-block ml-2" data-tip="<%= description %>">
+      <i class="fa-regular fa-circle-question fa-sm" style="color: #5eead4;"></i>
+    </div>
+  </div>
   <% if review.send("#{field_short}_unspecified?") %>
     評価なし
   <% else %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -20,9 +20,9 @@
     <div class="divider mt-0"></div>
 
     <div class="review_body space-y-4">
-      <%= render 'rating_field_for_show', field: :minimal_interaction, review: review, field_short: 'int' %>
-      <%= render 'rating_field_for_show', field: :equipment_customization, review: review, field_short: 'eqcust' %>
-      <%= render 'rating_field_for_show', field: :solo_friendly, review: review, field_short: 'sofr' %>
+      <%= render 'rating_field_for_show', field: :minimal_interaction, review: review, field_short: 'int', description: t('defaults.desc_of_int') %>
+      <%= render 'rating_field_for_show', field: :equipment_customization, review: review, field_short: 'eqcust', description: t('defaults.desc_of_eqcust') %>
+      <%= render 'rating_field_for_show', field: :solo_friendly, review: review, field_short: 'sofr', description: t('defaults.desc_of_sofr') %>
 
       <div class="comment space-y-1">
         <div class="attribure_name">

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -3,5 +3,9 @@
     <%= t('.title') %>
   </h1>
 
+  <div class="info mt-4">
+    <p class="text-xs italic">評価対象外にする場合は★0にしてください</p>
+  </div>
+
   <%= render "form", { review: @review } %>
 </div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -4,6 +4,4 @@
   </h1>
 
   <%= render "form", { review: @review } %>
-
-  <%= link_to t('defaults.back'), 'javascript:history.back()', class: 'btn btn-neutral' %>
 </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -3,5 +3,9 @@
     <%= t('.title', shop: @shop.name) %>
   </h1>
 
+  <div class="info mt-4">
+    <p class="text-xs italic">評価対象外にする場合は★0にしてください</p>
+  </div>
+
   <%= render "form", { shop: @shop, review: @review } %>
 </div>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -28,9 +28,9 @@ ja:
         opening_hours: 営業時間
         int_average: 接客の少なさ
         eqcust_average: 機器設定の自由度
-        sofr_average: ヒトカラーウェルカム度
+        sofr_average: ヒトカラーフレンドリー度
       review:
         minimal_interaction: 接客の少なさ
         equipment_customization: 機器設定の自由度
-        solo_friendly: ヒトカラーウェルカム度
+        solo_friendly: ヒトカラーフレンドリー度
         comment: コメント

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -112,6 +112,9 @@ ja:
     search_words: 検索ワード
     unspecified: 指定なし
     to_official_site: 公式サイトへ
+    desc_of_int: 店員さんとの接触機会は最小限？
+    desc_of_eqcust: 高度な設定変更ができる？持ち込み機材は使える？等
+    desc_of_sofr: 一人でも浮かない？
     terms: 利用規約
     privacy_policy: プライバシーポリシー
     contact: お問い合わせ


### PR DESCRIPTION
レビュー投稿・編集・詳細画面において、レーティグ項目横のアイコンにインタラクトすると説明が表示される機能を実装。

-  Font Awesomeを導入
- 各画面のレーティング項目ラベル横にTooltip機能付きのアイコンを追加

closes #146 