### PR TITLE
fix:スマホでのレイアウト崩れを修正

### DIFF
--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -10,9 +10,9 @@
     <%= form.label :gender, class: 'block my-2' %>
     <div class="flex flex-row gap-4">
       <% Profile.genders.each_key do |key| %>
-        <div class="flex flex-row content-center gap-2">
-          <%= form.radio_button :gender, key, class: "radio radio-primary" %>
-          <%= form.label :gender, Profile.genders_i18n[key], value: key %>
+        <div class="flex flex-row content-center gap-1">
+          <%= form.radio_button :gender, key, class: "radio radio-sm" %>
+          <%= form.label :gender, Profile.genders_i18n[key], value: key, class: 'text-sm' %>
         </div>
       <% end %>
     </div>
@@ -28,6 +28,6 @@
   </div>
 
   <div class="mt-6 text-center">
-    <%= form.submit class: "btn btn-accent btn-wide" %>
+    <%= form.submit class: "btn btn-accent" %>
   </div>
 <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<div class="card w-96 bg-neutral mx-auto">
+<div class="card w-full bg-neutral mx-auto">
   <div class="card-body">
     <h2 class="card-title">
       <%= @profile.name %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -3,16 +3,25 @@
     <%= link_to 'ロゴ', root_path, class: 'btn btn-ghost text-xl' %>
   </div>
   <div class="flex justify-end flex-1 px-2">
-    <div class="flex items-stretch gap-4">
-      <% if current_page?(signup_path) == false %>
-        <%= link_to t('users.new.title'), signup_path, class: 'btn btn-secondary btn-xs' %>
-      <% end %>
-      <% if current_page?(login_path) == false %>
-        <%= link_to t('defaults.login'), login_path, class: 'btn btn-primary btn-xs' %>
-      <% end %>
-      <% if current_page?(shops_path) == false %>
-        <%= link_to t('shops.index.title'), shops_path, class: 'btn btn-accent btn-xs' %>
-      <% end %>
+    <div class="flex items-center gap-x-2">
+    <!-- ボタンが１つなら↑は消していいかも -->
+      <%= link_to t('user_sessions.new.title'), login_path, class: 'btn btn-ghost text-accent' %>
+      <details class="dropdown dropdown-end">
+        <summary class="btn btn-ghost rounded-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+        </summary>
+        <ul class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52">
+          <li>
+            <%= link_to t('shops.index.title'), shops_path %>
+          </li>
+          <li>
+            <%= link_to t('users.new.title'), signup_path, data: {turbo_method: :delete} %>
+          </li>
+          <li>
+            <%= mail_to ENV['GMAIL_USERNAME'], t('defaults.contact') %>
+          </li>
+        </ul>
+      </details>
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,13 +1,12 @@
 <div class="navbar bg-neutral sticky top-0 z-10 rounded-box shadow-xl">
 
-  <div class="flex-1">
+  <div class="flex-1 gap-x-2">
     <%= link_to 'ロゴ', shops_path, class: 'btn btn-ghost text-xl' %>
-    <p class="text-xs"><%= current_user.name %></p>
+    <%= link_to current_user.name, mypage_path, class: 'text-xs' %>
   </div>
 
   <div class="flex justify-end flex-1 px-2">
     <div class="flex items-stretch">
-    <!-- ボタンが１つなら↑は消していいかも -->
       <details class="dropdown dropdown-end">
         <summary class="btn btn-ghost rounded-btn">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>


### PR DESCRIPTION
ログイン前のヘッダー、マイページ、プロフィール編集ページのレイアウト崩れを修正。

closes #98 