### PR TITLE
fix:ヘッダーロゴの拡張子を記述

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar bg-neutral sticky top-0 z-10 rounded-box shadow-xl">
   <div class="flex-1 px-2">
     <%= link_to root_path, class: 'btn btn-ghost p-0' do %>
-      <%= image_tag 'logo_long_text_and_stars', class: 'h-12 rounded-md' %>
+      <%= image_tag 'logo_long_text_and_stars.png', class: 'h-12 rounded-md' %>
     <% end %>
   </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
 
   <div class="flex-1 px-2">
     <%= link_to root_path, class: 'btn btn-ghost p-0' do %>
-      <%= image_tag 'logo_long_text_and_stars', class: 'h-12 rounded-md' %>
+      <%= image_tag 'logo_long_text_and_stars.png', class: 'h-12 rounded-md' %>
     <% end %>
   </div>
 


### PR DESCRIPTION
抜けていたヘッダーロゴの拡張子を追加。