### PR TITLE
店舗関連要素のデザインを修正

### DIFF
--- a/app/views/shared/_tooltip_icon.html.erb
+++ b/app/views/shared/_tooltip_icon.html.erb
@@ -1,0 +1,3 @@
+<div class="tooltip tooltip-info max-w-1/2 inline-block ml-2" data-tip="<%= description %>">
+  <i class="fa-solid fa-circle-question fa-sm" style="color: #b1d9e9;"></i>
+</div>

--- a/app/views/shared/_tooltip_icon.html.erb
+++ b/app/views/shared/_tooltip_icon.html.erb
@@ -1,3 +1,3 @@
-<div class="tooltip tooltip-info max-w-1/2 inline-block ml-2" data-tip="<%= description %>">
+<div class="tooltip tooltip-info before:max-w-56 before:content-[attr(data-tip)] inline-block content-center ml-2" data-tip="<%= description %>">
   <i class="fa-solid fa-circle-question fa-sm" style="color: #b1d9e9;"></i>
 </div>

--- a/app/views/shops/_latest_reviews.html.erb
+++ b/app/views/shops/_latest_reviews.html.erb
@@ -1,15 +1,12 @@
-<div class="card w-full bg-white">
-  <div class="card-body p-4">
-    <h2 class="card-title">レビュー</h2>
-    <% if shop.reviews.present? %>
-      <%= render partial:'shops/review', collection: reviews %>
-      <div class="card-actions justify-center mt-4">
-        <%= link_to t('.show_all_reviews'), shop_reviews_path(shop), class: 'btn btn-primary' %>
-      </div>
-    <% else %>
-      <div class="no_reviews text-center">
-        <p>まだレビューはありません。</p>
-      </div>
-    <% end %>
+<% if shop.reviews.present? %>
+  <div class="reviews flex flex-col gap-y-4">
+    <%= render partial:'shops/review', collection: reviews %>
   </div>
-</div>
+  <div class="text-center mt-6">
+    <%= link_to t('.show_all_reviews'), shop_reviews_path(shop), class: 'btn btn-primary' %>
+  </div>
+<% else %>
+  <div class="no_reviews text-center">
+    <p>まだレビューはありません。</p>
+  </div>
+<% end %>

--- a/app/views/shops/_rating_field_for_index.html.erb
+++ b/app/views/shops/_rating_field_for_index.html.erb
@@ -1,0 +1,16 @@
+<div class="grid grid-cols-[3fr_2fr]">
+  <div class="text-center pr-1 bg-base-200 rounded-lg">
+    <%= Shop.human_attribute_name(field) %>
+  </div>
+  <div class="pl-1">
+    <% if shop.send("#{field}") == 0 %>
+      評価なし
+    <% else %>
+      <span class="rating rating-sm">
+        <% 5.times do |n| %>
+          <%= radio_button_tag "shop_#{shop.id}[#{field}]", n + 1, shop.send("#{field}") == n + 1, { disabled: true, class: "mask mask-star-2 bg-orange-400 cursor-default" } %>
+        <% end %>
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shops/_rating_field_for_review.html.erb
+++ b/app/views/shops/_rating_field_for_review.html.erb
@@ -1,6 +1,8 @@
-<div class="space-y-2">
-  <p>
-    <%= Review.human_attribute_name(field) + ': ' %>
+<div class="grid grid-cols-[3fr_2fr]">
+  <div class="text-center pr-1 bg-base-200 rounded-lg">
+    <%= Review.human_attribute_name(field) %>
+  </div>
+  <div class="pl-1">
     <% if review.send("#{field_short}_unspecified?") %>
       評価なし
     <% else %>
@@ -10,5 +12,5 @@
         <% end %>
       </span>
     <% end %>
-  </p>
+  </div>
 </div>

--- a/app/views/shops/_rating_field_for_show.html.erb
+++ b/app/views/shops/_rating_field_for_show.html.erb
@@ -1,14 +1,17 @@
-<div class="text-sm text-right">
-  <p>
-    <%= Shop.human_attribute_name(field) + ': ' %>
+<div>
+  <div class="flex justify-center w-3/4 mx-auto bg-base-200 rounded-lg">
+    <%= Shop.human_attribute_name(field) %>
+    <%= render 'shared/tooltip_icon', description: description %>
+  </div>
+  <div class="w-3/4 mx-auto text-center pt-1">
     <% if shop.send("#{field}") == 0 %>
       評価なし
     <% else %>
-      <span class="rating rating-sm">
+      <span class="rating">
         <% 5.times do |n| %>
           <%= radio_button_tag "shop_#{shop.id}[#{field}]", n + 1, shop.send("#{field}") == n + 1, { disabled: true, class: "mask mask-star-2 bg-orange-400 cursor-default" } %>
         <% end %>
       </span>
     <% end %>
-  </p>
+  </div>
 </div>

--- a/app/views/shops/_review.html.erb
+++ b/app/views/shops/_review.html.erb
@@ -1,5 +1,5 @@
-<div class="card w-96 bg-base-100 mx-auto w-full shadow-xl">
-  <div class="card-body flex flex-col text-sm p-3.5">
+<div class="card w-96 bg-base-100 mx-auto w-full shadow-lg">
+  <div class="card-body text-sm p-3.5">
     <div class="review-header flex flex-col">
       <div class="user-name">
         <span class="font-bold"><%= review.user.name %></span>
@@ -19,15 +19,14 @@
 
     <div class="divider my-0"></div>
 
-    <div class="review_body gap-2">
-      <%= render 'rating_field_for_review', field: :minimal_interaction, review: review, field_short: 'int' %>
-      <%= render 'rating_field_for_review', field: :equipment_customization, review: review, field_short: 'eqcust' %>
-      <%= render 'rating_field_for_review', field: :solo_friendly, review: review, field_short: 'sofr' %>
+    <div class="review_body">
+      <div class="rating_fields flex flex-col p-3 gap-y-1">
+        <%= render 'rating_field_for_review', field: :minimal_interaction, review: review, field_short: 'int' %>
+        <%= render 'rating_field_for_review', field: :equipment_customization, review: review, field_short: 'eqcust' %>
+        <%= render 'rating_field_for_review', field: :solo_friendly, review: review, field_short: 'sofr' %>
+      </div>
 
-      <div class="comment space-y-1 mt-2">
-        <div class="attribure_name">
-          <%= Review.human_attribute_name(:comment) + ':' %>
-        </div>
+      <div class="comment mt-2">
         <div class="attribute-body p-2 rounded-lg bg-white/50 text-sm">
           <%= truncate(simple_format(review.comment), length: 50, omission: '…', escape: false, separator: '<') do %>
             <%= link_to '（続きを読む）', review_path(review), class: 'link' %>

--- a/app/views/shops/_search_form_for_shops.html.erb
+++ b/app/views/shops/_search_form_for_shops.html.erb
@@ -18,7 +18,10 @@
     <div class="rating_averages">
       <% Shop.average_attributes.each do |attr| %>
         <div class="average_items form-control">
-          <%= f.label attr, Shop.human_attribute_name(attr), class: 'label' %>
+          <div class="flex">
+            <%= f.label attr, Shop.human_attribute_name(attr), class: 'label' %>
+            <%= render 'shared/tooltip_icon', description: t("defaults.description.#{attr}") %>
+          </div>
           <%= f.select attr, Shop.averages_select_options, { include_blank: t('defaults.unspecified') }, class: 'select select-bordered select-sm select-primary' %>
         </div>
       <% end %>

--- a/app/views/shops/_search_form_for_shops.html.erb
+++ b/app/views/shops/_search_form_for_shops.html.erb
@@ -1,7 +1,7 @@
 <div class="card shrink-0 w-full max-w-sm mx-auto shadow-2xl bg-base-100">
-  <%= form_with model: search_shops_form, scope: :q, url: shops_url, method: :get, html: { data: { turbo_frame: 'shops-list' } }, class: 'card-body' do |f| %>
+  <%= form_with model: search_shops_form, scope: :q, url: shops_url, method: :get, html: { data: { turbo_frame: 'shops-list' } }, class: 'card-body p-6' do |f| %>
     <div class="location form-control">
-      <%= label_tag '', t('defaults.pref_and_area'), class: 'label' %>
+      <%= label_tag '', t('defaults.pref_and_area'), class: 'label pt-0' %>
       <%= turbo_frame_tag 'location-select-boxes' do %>
         <div class="join flex">
           <%= f.select :prefecture, Prefecture.selectable.map{ |p| [p.name, prefecture_areas_path(p)] }, { include_blank: t('defaults.unspecified') }, { onchange: "Turbo.visit(value, {frame: 'location-select-boxes'})", class: 'select select-bordered select-sm select-primary text-xs join-item' } %>

--- a/app/views/shops/_shop_buttons.html.erb
+++ b/app/views/shops/_shop_buttons.html.erb
@@ -1,4 +1,4 @@
-<div class="card-actions justify-center mt-4">
+<div class="card-actions justify-center mt-6">
   <%= link_to t('defaults.to_official_site'), shop.url, class: 'btn btn-primary', target: '_blank' %>
   <%= render 'shared/review_button', shop: shop %>
 </div>

--- a/app/views/shops/_shop_for_index.html.erb
+++ b/app/views/shops/_shop_for_index.html.erb
@@ -1,7 +1,7 @@
 <%= link_to shop_path(shop), data: {turbo: false} do %>
   <div class="card bg-base-100 mx-auto w-full my-6 shadow-lg active:bg-base-200" ontouchstart="">
     <div class="card-body p-6">
-      <h2 class="card-title text-base">
+      <h2 class="card-title text-lg">
         <%= shop.name %>
       </h2>
 
@@ -13,19 +13,20 @@
         <% end %>
       </div>
 
-      <div class="rating_averages gap-y-1 mt-4">
-        <%= render 'rating_field_for_shop', shop: shop, field: :int_average %>
-        <%= render 'rating_field_for_shop', shop: shop, field: :eqcust_average %>
-        <%= render 'rating_field_for_shop', shop: shop, field: :sofr_average %>
+      <div class="rating_averages flex flex-col p-3 gap-y-1 mt-3 text-sm">
+        <%= render 'rating_field_for_index', shop: shop, field: :int_average %>
+        <%= render 'rating_field_for_index', shop: shop, field: :eqcust_average %>
+        <%= render 'rating_field_for_index', shop: shop, field: :sofr_average %>
       </div>
 
-      <div class="static-informations space-y-4 mt-4 text-sm">
-        <div class="attribute">
-          <p>
-            <%= Shop.human_attribute_name(:address) + ':' %>
-            <br>
+      <div class="static-informations mt-3 text-sm">
+        <div class="address grid grid-cols-[1fr_8fr]">
+          <div>
+            <i class="fa-solid fa-location-dot"></i>
+          </div>
+          <div>
             <%= simple_format(shop.address) %>
-          </p>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/shops/_shop_for_index.html.erb
+++ b/app/views/shops/_shop_for_index.html.erb
@@ -13,13 +13,13 @@
         <% end %>
       </div>
 
-      <div class="rating_averages flex flex-col p-3 gap-y-1 mt-3 text-sm">
+      <div class="rating_averages flex flex-col mx-auto p-3 gap-y-1 mt-3 text-sm">
         <%= render 'rating_field_for_index', shop: shop, field: :int_average %>
         <%= render 'rating_field_for_index', shop: shop, field: :eqcust_average %>
         <%= render 'rating_field_for_index', shop: shop, field: :sofr_average %>
       </div>
 
-      <div class="static-informations mt-3 text-sm">
+      <div class="static-informations mx-auto px-2 mt-3 text-sm">
         <div class="address grid grid-cols-[1fr_8fr]">
           <div>
             <i class="fa-solid fa-location-dot"></i>

--- a/app/views/shops/_shop_for_show.html.erb
+++ b/app/views/shops/_shop_for_show.html.erb
@@ -4,7 +4,7 @@
       <%= shop.area.name %>
     </div>
 
-    <h2 class="card-title text-base">
+    <h2 class="card-title text-lg">
       <%= shop.name %>
     </h2>
 
@@ -17,35 +17,38 @@
       <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'link link-accent text-xs', data: { turbo: false } %>
     </div>
 
-    <div class="rating_averages gap-y-1 mt-4">
-      <%= render 'rating_field_for_shop', shop: shop, field: :int_average %>
-      <%= render 'rating_field_for_shop', shop: shop, field: :eqcust_average %>
-      <%= render 'rating_field_for_shop', shop: shop, field: :sofr_average %>
+    <div class="rating_averages flex flex-col gap-y-2 mt-4 p-2">
+      <%= render 'rating_field_for_show', shop: shop, field: :int_average, description: t('defaults.desc_of_int') %>
+      <%= render 'rating_field_for_show', shop: shop, field: :eqcust_average, description: t('defaults.desc_of_eqcust') %>
+      <%= render 'rating_field_for_show', shop: shop, field: :sofr_average, description: t('defaults.desc_of_sofr') %>
     </div>
 
-    <div class="static-informations space-y-4 mt-4 text-sm">
-      <div class="attribute">
-        <p>
-          <%= Shop.human_attribute_name(:address) + ':' %>
-          <br>
+    <div class="static-informations space-y-4 mt-4">
+      <div class="attribute grid grid-cols-[1fr_8fr]">
+        <div>
+          <i class="fa-solid fa-location-dot"></i>
+        </div>
+        <div>
           <%= simple_format(shop.address) %>
-        </p>
+        </div>
       </div>
 
-      <div class="attribute">
-        <p>
-          <%= Shop.human_attribute_name(:phone_number) + ':' %>
-          <br>
+      <div class="attribute grid grid-cols-[1fr_8fr]">
+        <div>
+          <i class="fa-solid fa-phone"></i>
+        </div>
+        <div>
           <%= link_to shop.phone_number, "tel:#{shop.phone_number}", class: 'link md:pointer-events-none md:no-underline' %>
-        </p>
+        </div>
       </div>
 
-      <div class="attribute">
-        <p>
-          <%= Shop.human_attribute_name(:opening_hours) + ':' %>
-          <br>
+      <div class="attribute grid grid-cols-[1fr_8fr]">
+        <div>
+          <i class="fa-solid fa-clock"></i>
+        </div>
+        <div>
           <%= simple_format(shop.opening_hours) %>
-        </p>
+        </div>
       </div>
     </div>
 

--- a/app/views/shops/_shop_for_show.html.erb
+++ b/app/views/shops/_shop_for_show.html.erb
@@ -14,16 +14,16 @@
           <%= tag.name %>
         </div>
       <% end %>
-      <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'link link-accent text-xs', data: { turbo: false } %>
+      <%= link_to t('defaults.edit_tags'), shop_tags_path(shop), class: 'inline-block link link-accent text-xs', data: { turbo: false } %>
     </div>
 
     <div class="rating_averages flex flex-col gap-y-2 mt-4 p-2">
-      <%= render 'rating_field_for_show', shop: shop, field: :int_average, description: t('defaults.desc_of_int') %>
-      <%= render 'rating_field_for_show', shop: shop, field: :eqcust_average, description: t('defaults.desc_of_eqcust') %>
-      <%= render 'rating_field_for_show', shop: shop, field: :sofr_average, description: t('defaults.desc_of_sofr') %>
+      <%= render 'rating_field_for_show', shop: shop, field: :int_average, description: t("defaults.description.int_average") %>
+      <%= render 'rating_field_for_show', shop: shop, field: :eqcust_average, description: t("defaults.description.eqcust_average") %>
+      <%= render 'rating_field_for_show', shop: shop, field: :sofr_average, description: t("defaults.description.sofr_average") %>
     </div>
 
-    <div class="static-informations space-y-4 mt-4">
+    <div class="static-informations mx-auto space-y-4 px-2 mt-4">
       <div class="attribute grid grid-cols-[1fr_8fr]">
         <div>
           <i class="fa-solid fa-location-dot"></i>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,3 +1,5 @@
 <%= render 'shop_for_show', shop: @shop %>
 
+<div class="divider mt-8 text-sm"><%= t('.latest_reviews') %></div>
+
 <%= render 'latest_reviews', shop: @shop, reviews: @reviews %>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -28,9 +28,9 @@ ja:
         opening_hours: 営業時間
         int_average: 接客の少なさ
         eqcust_average: 機器設定の自由度
-        sofr_average: ヒトカラーフレンドリー度
+        sofr_average: ヒトカラー歓迎度
       review:
         minimal_interaction: 接客の少なさ
         equipment_customization: 機器設定の自由度
-        solo_friendly: ヒトカラーフレンドリー度
+        solo_friendly: ヒトカラー歓迎度
         comment: コメント

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -111,9 +111,13 @@ ja:
     pref_and_area: 都道府県 / エリア
     name_or_address: 店名・住所
     to_official_site: 公式サイトへ
-    desc_of_int: 店員との接触機会は最小限？
-    desc_of_eqcust: 高度な設定変更や機材持ち込みができる？
-    desc_of_sofr: 一人でも行きやすい？
+    description:
+      int_average: 店員との接触機会は最小限？
+      eqcust_average: 高度な設定変更や機材持ち込みができる？
+      sofr_average: 一人でも行きやすい？
+      minimal_interaction: 店員との接触機会は最小限？
+      equipment_customization: 高度な設定変更や機材持ち込みができる？
+      solo_friendly: 一人でも行きやすい？
     terms: 利用規約
     privacy_policy: プライバシーポリシー
     contact: お問い合わせ

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -32,7 +32,7 @@ ja:
       title: カラオケを探す
       no_shops: 該当する店舗がありません
     show:
-      title: 店舗詳細
+      latest_reviews: 最新レビュー
     latest_reviews:
       show_all_reviews: すべてのレビューを見る
   profiles:
@@ -111,9 +111,9 @@ ja:
     pref_and_area: 都道府県 / エリア
     name_or_address: 店名・住所
     to_official_site: 公式サイトへ
-    desc_of_int: 店員さんとの接触機会は最小限？
-    desc_of_eqcust: 高度な設定変更ができる？持ち込み機材は使える？等
-    desc_of_sofr: 一人でも浮かない？
+    desc_of_int: 店員との接触機会は最小限？
+    desc_of_eqcust: 高度な設定変更や機材持ち込みができる？
+    desc_of_sofr: 一人でも行きやすい？
     terms: 利用規約
     privacy_policy: プライバシーポリシー
     contact: お問い合わせ


### PR DESCRIPTION
### 店舗一覧（検索フィールド）
- [x] ワード検索にもラベルつける？あるいは説明
- [x] 全体に文字小さい
- [x] 都道府県とエリアはjointしちゃう？
- [x] 検索ボタンサイズどうする？
- [x] レーティング国目の説明追加

### 店舗カード（一覧）
- [x] 文字もう少し大きくする？
- [x] ラベルをアイコンにする
- [x] スマホでタップした時色変わるようにする

### 店舗カード（詳細）
- [x] レビュー欄とはdividerとかで分ける？
- [x] 全体に文字小さい
- [x] ラベルをアイコンにする
