### PR TITLE
お気に入り店舗機能

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   SuggestExtensions: false
   Exclude:
     - 'vendor/**/*'
+    - 'db/schema.rb'
     - 'db/**/*'
     - 'bin/**/*'
     - 'spec/**/*'
@@ -31,6 +32,7 @@ Metrics/BlockLength:
     - 'Gemfile'
     - 'config/**/*'
     - 'spec/**/*_spec.rb'
+    - 'db/schema.rb'
 
 Metrics/ClassLength:
   CountComments: false

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,17 @@
+class FavoritesController < ApplicationController
+  before_action :set_shop
+
+  def create
+    current_user.favorite(@shop)
+  end
+
+  def destroy
+    current_user.unfavorite(@shop)
+  end
+
+  private
+
+  def set_shop
+    @shop = Shop.find(params[:shop_id])
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,16 +2,17 @@ class FavoritesController < ApplicationController
   before_action :set_shop
 
   def create
+    @shop = Shop.find(params[:shop_id])
     current_user.favorite(@shop)
   end
 
   def destroy
+    @shop = current_user.favorites.find(params[:id]).shop
     current_user.unfavorite(@shop)
   end
 
   private
 
   def set_shop
-    @shop = Shop.find(params[:shop_id])
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,5 +1,7 @@
 class FavoritesController < ApplicationController
-  before_action :set_shop
+  def index
+    @shops = current_user.shops.page(params[:page])
+  end
 
   def create
     @shop = Shop.find(params[:shop_id])
@@ -10,8 +12,4 @@ class FavoritesController < ApplicationController
     @shop = current_user.favorites.find(params[:id]).shop
     current_user.unfavorite(@shop)
   end
-
-  private
-
-  def set_shop; end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -13,6 +13,5 @@ class FavoritesController < ApplicationController
 
   private
 
-  def set_shop
-  end
+  def set_shop; end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -21,7 +21,7 @@ class ShopsController < ApplicationController
     @sort_shops_params = sort_shops_params
     @search_shops_form = SearchShopsForm.new(@search_shops_params)
     @all_shops = @search_shops_form.search
-    @shops = sort_shops(@all_shops).includes(:tags).page(params[:page])
+    @shops = sort_shops(@all_shops).includes(:tags, :favorites).page(params[:page])
   end
 
   def sort_shops(relation)

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,8 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :shop
+
+  validates :user_id, presence: true
+  validates :shop_id, presence: true
+  validates :user_id, uniqueness: { scope: :shop_id }
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,6 +4,7 @@ class Review < ApplicationRecord
   has_one :profile, through: :user
 
   validates :user_id, presence: true
+  validates :user_id, uniqueness: { scope: :shop_id }
   validates :shop_id, presence: true
   with_options presence: true do
     validates :minimal_interaction

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -4,6 +4,8 @@ class Shop < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :shop_tags
   has_many :tags, through: :shop_tags, dependent: :destroy
+  has_many :favorites
+  has_many :users, through: :favorites, dependent: :destroy
 
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 

--- a/app/models/shop_tag.rb
+++ b/app/models/shop_tag.rb
@@ -3,5 +3,6 @@ class ShopTag < ApplicationRecord
   belongs_to :tag
 
   validates :shop_id, presence: true
+  validates :shop_id, uniqueness: { scope: :tag_id }
   validates :tag_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,4 +56,12 @@ class User < ApplicationRecord
       "(#{gender_i18n})"
     end
   end
+
+  def favorite(shop)
+    shops << shop
+  end
+
+  def unfavorite(shop)
+    shops.delete(shop)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,10 @@ class User < ApplicationRecord
     end
   end
 
+  def favorite?(shop)
+    shop.favorites.pluck(:user_id).include?(id)
+  end
+
   def favorite(shop)
     shops << shop
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
 
   has_one :profile, dependent: :destroy
   has_many :reviews, dependent: :destroy
+  has_many :favorites
+  has_many :shops, through: :favorites, dependent: :destroy
 
   validates :password, length: { minimum: 8 }, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password, presence: true, on: :reset_password

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "fav-button-for-shop-#{@shop.id}" do %>
+  <%= render 'shops/unfavorite', shop: @shop %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "fav-button-for-shop-#{@shop.id}" do %>
+<%= turbo_stream.replace "unfav-button-for-shop-#{@shop.id}" do %>
   <%= render 'shops/favorite', shop: @shop %>
 <% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "fav-button-for-shop-#{@shop.id}" do %>
+  <%= render 'shops/favorite', shop: @shop %>
+<% end %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t('.title') %>
+
+<div class="title mb-8">
+  <h1 class="font-bold text-2xl text-neutral text-center">
+    <%= t('.title') %>
+  </h1>
+</div>
+
+<div class="flex flex-col w-full border-opacity-50">
+  <%= turbo_frame_tag 'shops-list' do %>
+    <% if @shops.present? %>
+      <%= render partial: 'shops/shop_summary', collection: @shops, as: :shop %>
+      <%= render 'shared/pagination', object: @shops %>
+    <% else %>
+      <p class="text-center"><%= t '.no_shops' %></p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,6 +1,12 @@
 <% content_for :title, t('.title') %>
 
-<div class="card w-full bg-base-100 mx-auto shadow-lg">
+<div class="title mb-4 text-center">
+  <h1 class="font-bold text-2xl text-neutral">
+    <%= t '.title' %>
+  </h1>
+</div>
+
+<div class="card w-full bg-base-100 mx-auto max-w-xs shadow-lg">
   <div class="card-body">
     <h2 class="card-title">
       <%= @profile.name %>
@@ -19,6 +25,7 @@
   </div>
 </div>
 
-<div class="flex justify-center mx-auto mt-8">
+<div class="text-center mx-auto mt-8">
   <%= link_to t('.to_my_reviews'), my_review_path, class: 'btn btn-wide btn-primary' %>
+  <%= link_to t('.to_favorites'), favorites_path, class: 'btn btn-wide btn-primary mt-4' %>
 </div>

--- a/app/views/shops/_fav_buttons.html.erb
+++ b/app/views/shops/_fav_buttons.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.favorite?(shop) %>
+  <%= render 'shops/unfavorite', shop: shop %>
+<% else %>
+  <%= render 'shops/favorite', shop: shop %>
+<% end %>

--- a/app/views/shops/_favorite.html.erb
+++ b/app/views/shops/_favorite.html.erb
@@ -1,3 +1,3 @@
 <%= link_to shop_favorites_path(shop), id: "fav-button-for-shop-#{shop.id}", data: {turbo_method: :post} do %>
-  <i class="fa-regular fa-heart"></i>
+  <i class="fa-regular fa-heart text-red-400"></i>
 <% end %>

--- a/app/views/shops/_favorite.html.erb
+++ b/app/views/shops/_favorite.html.erb
@@ -1,0 +1,3 @@
+<%= link_to shop_favorites_path(shop), id: "fav-button-for-shop-#{shop.id}", data: {turbo_method: :post} do %>
+  <i class="fa-regular fa-heart"></i>
+<% end %>

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -1,5 +1,8 @@
 <div class="card bg-primary/10 mx-auto w-full my-6 shadow-xl">
   <div class="card-body p-6">
+    <div class="fav-button text-lg text-right h-auto">
+      <%= render 'fav_buttons', shop: shop %>
+    </div>
     <div class="area text-xs text-right">
       <%= shop.area.name %>
     </div>

--- a/app/views/shops/_shop_summary.html.erb
+++ b/app/views/shops/_shop_summary.html.erb
@@ -3,6 +3,7 @@
     <div class="card-body p-6">
       <h2 class="card-title text-lg">
         <%= shop.name %>
+        <%= render 'fav_buttons', shop: shop %>
       </h2>
 
       <div class="tags">

--- a/app/views/shops/_shop_summary.html.erb
+++ b/app/views/shops/_shop_summary.html.erb
@@ -37,13 +37,9 @@
         </div>
       </div>
     </div>
-  </div>
 
-  <figure class="bg-primary active:bg-lime-700" ontouchstart="">
-    <%= link_to shop_path(shop), data: {turbo: false}, class: 'w-full' do %>
-      <div class="text-center p-4">
-        <%= t('defaults.show') %>
-      </div>
-    <% end %>
-  </figure>
+    <div class="card-actions justify-center mt-4">
+      <%= link_to t('defaults.show'), shop_path(shop), data: {turbo: false}, class: 'btn btn-primary btn-wide' %>
+    </div>
+  </div>
 </div>

--- a/app/views/shops/_shop_summary.html.erb
+++ b/app/views/shops/_shop_summary.html.erb
@@ -1,6 +1,6 @@
 <div class="card bg-primary/10 mx-auto w-full my-6 shadow-lg">
   <div class="card-body p-6">
-    <div class="text-right mt-0">
+    <div class="text-right text-lg mt-0">
       <%= render 'fav_buttons', shop: shop %>
     </div>
 

--- a/app/views/shops/_shop_summary.html.erb
+++ b/app/views/shops/_shop_summary.html.erb
@@ -1,7 +1,7 @@
 <div class="card bg-primary/10 mx-auto w-full my-6 shadow-lg">
   <div class="card-body p-6">
     <div class="text-right text-lg mt-0">
-      <%= render 'fav_buttons', shop: shop %>
+      <%= render 'shops/fav_buttons', shop: shop %>
     </div>
 
     <h2 class="card-title text-lg">
@@ -20,9 +20,9 @@
       <div class="indicator w-full">
         <span class="indicator-item indicator-bottom indicator-center badge badge-secondary badge-sm rounded"><%= t('defaults.preferences_rating') %></span>
         <div class="flex flex-col mx-auto gap-y-1 text-sm px-3 pt-3 pb-4 mt-3 rounded-lg border border-dotted border-secondary">
-          <%= render 'rating_for_index', shop: shop, field: :int_average %>
-          <%= render 'rating_for_index', shop: shop, field: :eqcust_average %>
-          <%= render 'rating_for_index', shop: shop, field: :sofr_average %>
+          <%= render 'shops/rating_for_index', shop: shop, field: :int_average %>
+          <%= render 'shops/rating_for_index', shop: shop, field: :eqcust_average %>
+          <%= render 'shops/rating_for_index', shop: shop, field: :sofr_average %>
         </div>
       </div>
     </div>

--- a/app/views/shops/_shop_summary.html.erb
+++ b/app/views/shops/_shop_summary.html.erb
@@ -1,40 +1,49 @@
-<%= link_to shop_path(shop), data: {turbo: false} do %>
-  <div class="card bg-primary/10 mx-auto w-full my-6 shadow-lg active:bg-base-200" ontouchstart="">
-    <div class="card-body p-6">
-      <h2 class="card-title text-lg">
-        <%= shop.name %>
-        <%= render 'fav_buttons', shop: shop %>
-      </h2>
+<div class="card bg-primary/10 mx-auto w-full my-6 shadow-lg">
+  <div class="card-body p-6">
+    <div class="text-right mt-0">
+      <%= render 'fav_buttons', shop: shop %>
+    </div>
 
-      <div class="tags">
-        <% shop.tags.each do |tag| %>
-          <div class="badge badge-accent badge-sm">
-            <%= tag.name %>
-          </div>
-        <% end %>
-      </div>
+    <h2 class="card-title text-lg">
+      <%= shop.name %>
+    </h2>
 
-      <div class="rating_averages">
-        <div class="indicator w-full">
-          <span class="indicator-item indicator-bottom indicator-center badge badge-secondary badge-sm rounded"><%= t('defaults.preferences_rating') %></span>
-          <div class="flex flex-col mx-auto gap-y-1 text-sm px-3 pt-3 pb-4 mt-3 rounded-lg border border-dotted border-secondary">
-            <%= render 'rating_for_index', shop: shop, field: :int_average %>
-            <%= render 'rating_for_index', shop: shop, field: :eqcust_average %>
-            <%= render 'rating_for_index', shop: shop, field: :sofr_average %>
-          </div>
+    <div class="tags">
+      <% shop.tags.each do |tag| %>
+        <div class="badge badge-accent badge-sm">
+          <%= tag.name %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="rating_averages">
+      <div class="indicator w-full">
+        <span class="indicator-item indicator-bottom indicator-center badge badge-secondary badge-sm rounded"><%= t('defaults.preferences_rating') %></span>
+        <div class="flex flex-col mx-auto gap-y-1 text-sm px-3 pt-3 pb-4 mt-3 rounded-lg border border-dotted border-secondary">
+          <%= render 'rating_for_index', shop: shop, field: :int_average %>
+          <%= render 'rating_for_index', shop: shop, field: :eqcust_average %>
+          <%= render 'rating_for_index', shop: shop, field: :sofr_average %>
         </div>
       </div>
+    </div>
 
-      <div class="static-informations mx-auto px-2 mt-5 text-sm">
-        <div class="address grid grid-cols-[1fr_8fr]">
-          <div>
-            <i class="fa-solid fa-location-dot"></i>
-          </div>
-          <div>
-            <%= simple_format(shop.address) %>
-          </div>
+    <div class="static-informations mx-auto px-2 mt-5 text-sm">
+      <div class="address grid grid-cols-[1fr_8fr]">
+        <div>
+          <i class="fa-solid fa-location-dot"></i>
+        </div>
+        <div>
+          <%= simple_format(shop.address) %>
         </div>
       </div>
     </div>
   </div>
-<% end %>
+
+  <figure class="bg-primary active:bg-lime-700" ontouchstart="">
+    <%= link_to shop_path(shop), data: {turbo: false}, class: 'w-full' do %>
+      <div class="text-center p-4">
+        <%= t('defaults.show') %>
+      </div>
+    <% end %>
+  </figure>
+</div>

--- a/app/views/shops/_unfavorite.html.erb
+++ b/app/views/shops/_unfavorite.html.erb
@@ -1,3 +1,3 @@
-<%= link_to favorite_path(shop.favorites.find{ |f| f.user_id == current_user.id }), id: "unfavorite-button-for-shop-#{shop.id}", data: { turbo_method: :delete} do %>
-  <i class="fa-solid fa-heart"></i>
+<%= link_to favorite_path(shop.favorites.find{ |f| f.user_id == current_user.id }), id: "unfav-button-for-shop-#{shop.id}", data: { turbo_method: :delete} do %>
+  <i class="fa-solid fa-heart text-red-400"></i>
 <% end %>

--- a/app/views/shops/_unfavorite.html.erb
+++ b/app/views/shops/_unfavorite.html.erb
@@ -1,0 +1,3 @@
+<%= link_to favorite_path(shop.favorites.find{ |f| f.user_id == current_user.id }), id: "unfavorite-button-for-shop-#{shop.id}", data: { turbo_method: :delete} do %>
+  <i class="fa-solid fa-heart"></i>
+<% end %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -54,6 +54,7 @@ ja:
     show:
       title: マイページ
       to_my_reviews: 投稿したレビュー一覧を見る
+      to_favorites: お気に入り店舗一覧を見る
     edit:
       title: プロフィール編集
     form:
@@ -79,6 +80,9 @@ ja:
     index:
       title: "%{shop}のタグ編集"
       done_and_to_show_shops: 完了して店舗詳細へ
+  favorites:
+    index:
+      title: お気に入り店舗一覧
   password_resets:
     new:
       title: パスワードリセット申請

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+
   namespace :admin do
     root 'dashboards#index'
     resources :users
@@ -11,18 +13,18 @@ Rails.application.routes.draw do
     get 'prefectures/:prefecture_id/areas', to: 'prefecture_areas#index', as: :prefecture_areas
   end
 
-  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
-
+  
   resources :password_resets, only: %i[create edit update]
   resource :password_resets, only: :new
-
+  
   get 'prefectures/:prefecture_id/areas', to: 'areas#index', as: :prefecture_areas
-
+  
   get 'shop_locations', to: 'shop_locations#index'
-
+  
   resources :shops, only: %i[index show], shallow: true do
     resources :reviews
     resources :shop_tags, path: :tags, only: %i[index create destroy], as: :tags
+    resources :favorites, only: %i[create destroy]
   end
 
   get 'my_review', to: 'my_reviews#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,10 @@ Rails.application.routes.draw do
   resources :shops, only: %i[index show], shallow: true do
     resources :reviews
     resources :shop_tags, path: :tags, only: %i[index create destroy], as: :tags
-    resources :favorites, only: %i[create destroy]
+    resources :favorites, only: :create
   end
+
+  resources :favorites, only: %i[index destroy]
 
   get 'my_review', to: 'my_reviews#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,14 +13,13 @@ Rails.application.routes.draw do
     get 'prefectures/:prefecture_id/areas', to: 'prefecture_areas#index', as: :prefecture_areas
   end
 
-  
   resources :password_resets, only: %i[create edit update]
   resource :password_resets, only: :new
-  
+
   get 'prefectures/:prefecture_id/areas', to: 'areas#index', as: :prefecture_areas
-  
+
   get 'shop_locations', to: 'shop_locations#index'
-  
+
   resources :shops, only: %i[index show], shallow: true do
     resources :reviews
     resources :shop_tags, path: :tags, only: %i[index create destroy], as: :tags

--- a/db/fixtures/development/07_favorites.rb
+++ b/db/fixtures/development/07_favorites.rb
@@ -1,0 +1,14 @@
+number_of_users = User.count
+number_of_shops = Shop.count
+
+shops = Shop.pluck(:id)
+
+number_of_users.times do |n_u|
+  random_shops = shops.shuffle
+  rand(number_of_shops).times do |n_s|
+    Favorite.seed(:user_id, :shop_id) do |s|
+      s.user_id = n_u + 1
+      s.shop_id = random_shops.shift
+    end
+  end
+end

--- a/db/migrate/20240519070601_create_favorites.rb
+++ b/db/migrate/20240519070601_create_favorites.rb
@@ -1,0 +1,12 @@
+class CreateFavorites < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :shop, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :favorites, [:user_id, :shop_id], unique: true
+  end
+end

--- a/db/migrate/20240519070601_create_favorites.rb
+++ b/db/migrate/20240519070601_create_favorites.rb
@@ -7,6 +7,6 @@ class CreateFavorites < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :favorites, [:user_id, :shop_id], unique: true
+    add_index :favorites, %i[user_id shop_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,103 +10,115 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_24_123527) do
+ActiveRecord::Schema[7.0].define(version: 20_240_519_070_601) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "areas", force: :cascade do |t|
-    t.bigint "prefecture_id", null: false
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["prefecture_id"], name: "index_areas_on_prefecture_id"
+  create_table 'areas', force: :cascade do |t|
+    t.bigint 'prefecture_id', null: false
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['prefecture_id'], name: 'index_areas_on_prefecture_id'
   end
 
-  create_table "prefectures", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_prefectures_on_name", unique: true
+  create_table 'favorites', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'shop_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['shop_id'], name: 'index_favorites_on_shop_id'
+    t.index %w[user_id shop_id], name: 'index_favorites_on_user_id_and_shop_id', unique: true
+    t.index ['user_id'], name: 'index_favorites_on_user_id'
   end
 
-  create_table "profiles", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "name", limit: 30, default: "名無しのヒトカラー", null: false
-    t.integer "gender", default: 0, null: false
-    t.integer "age_group", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_profiles_on_user_id"
+  create_table 'prefectures', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['name'], name: 'index_prefectures_on_name', unique: true
   end
 
-  create_table "reviews", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "shop_id", null: false
-    t.integer "minimal_interaction", default: 3, null: false
-    t.integer "equipment_customization", default: 3, null: false
-    t.integer "solo_friendly", default: 3, null: false
-    t.text "comment"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["shop_id"], name: "index_reviews_on_shop_id"
-    t.index ["user_id", "shop_id"], name: "index_reviews_on_user_id_and_shop_id", unique: true
-    t.index ["user_id"], name: "index_reviews_on_user_id"
+  create_table 'profiles', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.string 'name', limit: 30, default: '名無しのヒトカラー', null: false
+    t.integer 'gender', default: 0, null: false
+    t.integer 'age_group', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_profiles_on_user_id'
   end
 
-  create_table "shop_tags", force: :cascade do |t|
-    t.bigint "shop_id", null: false
-    t.bigint "tag_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["shop_id", "tag_id"], name: "index_shop_tags_on_shop_id_and_tag_id", unique: true
-    t.index ["shop_id"], name: "index_shop_tags_on_shop_id"
-    t.index ["tag_id"], name: "index_shop_tags_on_tag_id"
+  create_table 'reviews', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'shop_id', null: false
+    t.integer 'minimal_interaction', default: 3, null: false
+    t.integer 'equipment_customization', default: 3, null: false
+    t.integer 'solo_friendly', default: 3, null: false
+    t.text 'comment'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['shop_id'], name: 'index_reviews_on_shop_id'
+    t.index %w[user_id shop_id], name: 'index_reviews_on_user_id_and_shop_id', unique: true
+    t.index ['user_id'], name: 'index_reviews_on_user_id'
   end
 
-  create_table "shops", force: :cascade do |t|
-    t.bigint "area_id", null: false
-    t.string "name", null: false
-    t.string "address", null: false
-    t.string "phone_number"
-    t.string "url"
-    t.string "opening_hours"
-    t.decimal "latitude", precision: 9, scale: 6, null: false
-    t.decimal "longitude", precision: 9, scale: 6, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "int_average", default: 0, null: false
-    t.integer "eqcust_average", default: 0, null: false
-    t.integer "sofr_average", default: 0, null: false
-    t.index ["area_id"], name: "index_shops_on_area_id"
-    t.index ["name", "address"], name: "index_shops_on_name_and_address", unique: true
+  create_table 'shop_tags', force: :cascade do |t|
+    t.bigint 'shop_id', null: false
+    t.bigint 'tag_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[shop_id tag_id], name: 'index_shop_tags_on_shop_id_and_tag_id', unique: true
+    t.index ['shop_id'], name: 'index_shop_tags_on_shop_id'
+    t.index ['tag_id'], name: 'index_shop_tags_on_tag_id'
   end
 
-  create_table "tags", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'shops', force: :cascade do |t|
+    t.bigint 'area_id', null: false
+    t.string 'name', null: false
+    t.string 'address', null: false
+    t.string 'phone_number'
+    t.string 'url'
+    t.string 'opening_hours'
+    t.decimal 'latitude', precision: 9, scale: 6, null: false
+    t.decimal 'longitude', precision: 9, scale: 6, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'int_average', default: 0, null: false
+    t.integer 'eqcust_average', default: 0, null: false
+    t.integer 'sofr_average', default: 0, null: false
+    t.index ['area_id'], name: 'index_shops_on_area_id'
+    t.index %w[name address], name: 'index_shops_on_name_and_address', unique: true
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "crypted_password"
-    t.string "salt"
-    t.integer "role", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_token_expires_at"
-    t.datetime "reset_password_email_sent_at"
-    t.integer "access_count_to_reset_password_page", default: 0
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
+  create_table 'tags', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  add_foreign_key "areas", "prefectures"
-  add_foreign_key "profiles", "users"
-  add_foreign_key "reviews", "shops"
-  add_foreign_key "reviews", "users"
-  add_foreign_key "shop_tags", "shops"
-  add_foreign_key "shop_tags", "tags"
-  add_foreign_key "shops", "areas"
+  create_table 'users', force: :cascade do |t|
+    t.string 'email', null: false
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.integer 'role', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_token_expires_at'
+    t.datetime 'reset_password_email_sent_at'
+    t.integer 'access_count_to_reset_password_page', default: 0
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token'
+  end
+
+  add_foreign_key 'areas', 'prefectures'
+  add_foreign_key 'favorites', 'shops'
+  add_foreign_key 'favorites', 'users'
+  add_foreign_key 'profiles', 'users'
+  add_foreign_key 'reviews', 'shops'
+  add_foreign_key 'reviews', 'users'
+  add_foreign_key 'shop_tags', 'shops'
+  add_foreign_key 'shop_tags', 'tags'
+  add_foreign_key 'shops', 'areas'
 end


### PR DESCRIPTION
- 店舗一覧および詳細にお気に入りボタンを設置
- マイページ内にお気に入り店舗一覧へのリンクボタンを設置

お気に入りボタンの追加に伴い、一覧表示の際の店舗カードに「詳細」ボタンを追加。カードそのものをクリック/タップして詳細ページ遷移する従来の方式から、「詳細」ボタンで遷移する方式に変更。

closes #206 