### PR TITLE
マイページ周りのページ構成を変更

### DIFF
--- a/app/controllers/my_pages_controller.rb
+++ b/app/controllers/my_pages_controller.rb
@@ -1,0 +1,5 @@
+class MyPagesController < ApplicationController
+  def index
+    @user = current_user
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -9,7 +9,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @profile.update(profile_params)
-      redirect_to mypage_path, success: t('defaults.flash_message.updated', item: Profile.model_name.human)
+      redirect_to my_page_path, success: t('defaults.flash_message.updated', item: Profile.model_name.human)
     else
       flash.now[:error] = t('defaults.flash_message.not_updated', item: Profile.model_name.human)
       render :edit, status: :unprocessable_entity

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,9 @@
 class ProfilesController < ApplicationController
-  before_action :set_profile
+  before_action :set_my_profile, only: %i[edit update]
 
-  def show; end
+  def show
+    @profile = Profile.find_by(user_id: params[:user_id])
+  end
 
   def edit; end
 
@@ -16,7 +18,7 @@ class ProfilesController < ApplicationController
 
   private
 
-  def set_profile
+  def set_my_profile
     @profile = Profile.find_by(user_id: current_user.id)
   end
 

--- a/app/controllers/user_reviews_controller.rb
+++ b/app/controllers/user_reviews_controller.rb
@@ -1,5 +1,6 @@
 class UserReviewsController < ApplicationController
   def index
-    @reviews = current_user.reviews.includes(:shop).order(updated_at: :desc).page(params[:page])
+    @user = User.find(params[:user_id])
+    @reviews = @user.reviews.includes(:shop).order(updated_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/user_reviews_controller.rb
+++ b/app/controllers/user_reviews_controller.rb
@@ -1,4 +1,4 @@
-class MyReviewsController < ApplicationController
+class UserReviewsController < ApplicationController
   def index
     @reviews = current_user.reviews.includes(:shop).order(updated_at: :desc).page(params[:page])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   has_one :profile, dependent: :destroy
   has_many :reviews, dependent: :destroy
-  has_many :favorites
+  has_many :favorites, dependent: :destroy
   has_many :shops, through: :favorites, dependent: :destroy
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -7,8 +7,8 @@
 </div>
 
 <div class="text-center mx-auto mt-8">
-  <%= link_to t('.to_my_profiles'), user_profile_path(@user), class: 'btn btn-wide btn-primary' %>
-  <%= link_to t('.to_my_reviews'), user_reviews_path(@user), class: 'btn btn-wide btn-primary' %>
-  <%= link_to t('.to_favorites'), favorites_path, class: 'btn btn-wide btn-primary mt-4' %>
-  <%= link_to t('.delete_user'), user_path, data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete_user') }, class: 'btn btn-wide mt-4' %>
+  <%= link_to t('.my_profile'), user_profile_path(@user), class: 'btn btn-wide btn-primary' %>
+  <%= link_to t('.my_reviews'), user_reviews_path(@user), class: 'btn btn-wide btn-primary mt-4' %>
+  <%= link_to t('.favorites'), favorites_path, class: 'btn btn-wide btn-primary mt-4' %>
+  <%= link_to t('.delete_user'), user_path, data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete_user') }, class: 'btn btn-wide bg-red-700 text-white mt-4' %>
 </div>

--- a/app/views/my_pages/index.html.erb
+++ b/app/views/my_pages/index.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, t('.title') %>
+
+<div class="title mb-4 text-center">
+  <h1 class="font-bold text-2xl text-neutral">
+    <%= t '.title' %>
+  </h1>
+</div>
+
+<div class="text-center mx-auto mt-8">
+  <%= link_to t('.to_my_profiles'), user_profile_path(@user), class: 'btn btn-wide btn-primary' %>
+  <%= link_to t('.to_my_reviews'), user_reviews_path(@user), class: 'btn btn-wide btn-primary' %>
+  <%= link_to t('.to_favorites'), favorites_path, class: 'btn btn-wide btn-primary mt-4' %>
+  <%= link_to t('.delete_user'), user_path, data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete_user') }, class: 'btn btn-wide mt-4' %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -17,14 +17,21 @@
     <p>
       <%= Profile.human_attribute_name(:age_group) + ': ' + @profile.age_group_i18n %>
     </p>
-    <div class="card-actions justify-end" ontouchstart="">
-      <%= link_to edit_profile_path(@profile), class: 'px-1.5 rounded text-secondary text-lg active:bg-base-200' do %>
-        <i class="fa-solid fa-pen-to-square"></i>
-      <% end %>
-    </div>
+
+    <% if @profile.user == current_user %>
+      <div class="card-actions justify-end" ontouchstart="">
+        <%= link_to edit_profile_path(@profile), class: 'px-1.5 rounded text-secondary text-lg active:bg-base-200' do %>
+          <i class="fa-solid fa-pen-to-square"></i>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>
 
 <div class="text-center mx-auto mt-8">
-  <%= link_to t('.back_to_mypage'), my_page_path, class: 'btn btn-wide btn-primary' %>
+  <% if @profile.user == current_user %>
+    <%= link_to t('.back_to_my_page'), my_page_path, class: 'btn btn-wide btn-primary mt-4' %>
+  <% else %>
+    <%= link_to t('.this_users_reviews'), user_reviews_path(@profile.user), class: 'btn btn-wide btn-primary' %>
+  <% end %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -26,7 +26,5 @@
 </div>
 
 <div class="text-center mx-auto mt-8">
-  <%= link_to t('.to_my_reviews'), my_review_path, class: 'btn btn-wide btn-primary' %>
-  <%= link_to t('.to_favorites'), favorites_path, class: 'btn btn-wide btn-primary mt-4' %>
-  <%= link_to t('.delete_user'), user_path, data: { turbo_method: :delete, turbo_confirm: t('.confirm_delete_user') }, class: 'btn btn-wide mt-4' %>
+  <%= link_to t('.back_to_mypage'), my_page_path, class: 'btn btn-wide btn-primary' %>
 </div>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -6,7 +6,7 @@
           <i class="fa-solid fa-shop"></i>
         </div>
         <div class="font-bold pl-1">
-          <%= review.shop.name %>
+          <%= link_to shop.name, shop_path(shop), class: 'link' %>
         </div>
       </div>
       <div class="user-info grid grid-cols-[1fr_9fr]">
@@ -14,7 +14,7 @@
           <i class="fa-solid fa-user"></i>
         </div>
         <div class="pl-1 break-all">
-          <span class="font-bold"><%= review.user.name %></span>
+          <%= link_to review.user.name, user_profile_path(review.user), class: 'link font-bold' %>
           <span class="text-xs inline-block"> さん</span>
           <% if review.user.profile_displayable? %>
             <span class="text-xs inline-block">

--- a/app/views/reviews/_review_summary.html.erb
+++ b/app/views/reviews/_review_summary.html.erb
@@ -2,7 +2,7 @@
   <div class="card w-96 bg-accent/10 mx-auto w-full shadow-lg active:bg-base-200" ontouchstart=""">
     <div class="card-body text-sm p-6">
       <div class="review-header flex flex-col">
-        <% if current_page?(my_review_path) %>
+        <% if controller.class.to_s == 'UserReviewsController' %>
           <div class="shop-name grid grid-cols-[1fr_9fr]">
             <div class="text-center">
               <i class="fa-solid fa-shop"></i>
@@ -12,7 +12,7 @@
             </div>
           </div>
         <% end %>
-        <% if current_page?(my_review_path) == false %>
+        <% if controller.class.to_s == 'ShopsController' %>
           <div class="user-info grid grid-cols-[1fr_9fr]">
             <div class="text-center">
               <i class="fa-solid fa-user"></i>

--- a/app/views/reviews/_review_summary.html.erb
+++ b/app/views/reviews/_review_summary.html.erb
@@ -11,8 +11,7 @@
               <span class="font-bold"><%= review.shop.name %></span>
             </div>
           </div>
-        <% end %>
-        <% if controller.class.to_s == 'ShopsController' %>
+        <% else %>
           <div class="user-info grid grid-cols-[1fr_9fr]">
             <div class="text-center">
               <i class="fa-solid fa-user"></i>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
 
   <div class="flex justify-end flex-1 px-2">
     <div class="flex items-center gap-x-2">
-      <%= link_to current_user.name, mypage_path, class: 'btn btn-ghost text-xs' %>
+      <%= link_to current_user.name, my_page_path, class: 'btn btn-ghost text-xs' %>
       <details class="dropdown dropdown-end">
         <summary class="btn btn-ghost rounded-btn">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
@@ -18,7 +18,7 @@
             <%= link_to t('shops.index.title'), shop_locations_path %>
           </li>
           <li>
-            <%= link_to t('profiles.show.title'), mypage_path %>
+            <%= link_to t('profiles.show.title'), my_page_path %>
           </li>
           <li>
             <%= mail_to ENV['GMAIL_USERNAME'], t('defaults.contact') %>

--- a/app/views/user_reviews/index.html.erb
+++ b/app/views/user_reviews/index.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, t('.title') %>
+<% content_for :title, t('.title', user: @user.name) %>
 
 <div class="mb-4">
   <h1 class="font-bold text-2xl text-neutral text-center">
-    <%= t('.title') %>
+    <%= t('.title', user: @user.name) %>
   </h1>
 </div>
 
@@ -12,11 +12,15 @@
       <%= render partial: 'reviews/review_summary', collection: @reviews, as: :review %>
     </div>
   <% else %>
-    <p><%= t '.no_reviews' %></p>
+    <p class="text-center"><%= t '.no_reviews' %></p>
   <% end %>
   <%= render 'shared/pagination', object: @reviews %>
 <% end %>
 
 <div class="text-center mt-6">
-  <%= link_to t('.back_to_mypage'), my_page_path, class: 'btn btn-primary btn-wide' %>
+  <% if @user == current_user %>
+    <%= link_to t('.back_to_mypage'), my_page_path, class: 'btn btn-primary btn-wide' %>
+  <% else %>
+    <%= link_to t('.user_profile'), user_profile_path(@user), class: 'btn btn-primary btn-wide' %>
+  <% end %>
 </div>

--- a/app/views/user_reviews/index.html.erb
+++ b/app/views/user_reviews/index.html.erb
@@ -18,5 +18,5 @@
 <% end %>
 
 <div class="text-center mt-6">
-  <%= link_to t('.back_to_mypage'), mypage_path, class: 'btn btn-primary btn-wide' %>
+  <%= link_to t('.back_to_mypage'), my_page_path, class: 'btn btn-primary btn-wide' %>
 </div>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -56,13 +56,19 @@ ja:
       int_desc: 接客レス度 高評価順
       eqcust_desc: 機器設定の自由度 高評価順
       sofr_desc: 一人利用のしやすさ 高評価順
-  profiles:
-    show:
+  my_pages:
+    index:
       title: マイページ
-      to_my_reviews: 投稿したレビュー一覧を見る
-      to_favorites: お気に入り店舗一覧を見る
+      my_profile: プロフィール
+      my_reviews: 投稿したレビュー一覧
+      favorites: お気に入り店舗一覧
       delete_user: アカウントを削除する
       confirm_delete_user: 本当にアカウントを削除しますか？この操作は取り消せません
+  profiles:
+    show:
+      title: プロフィール
+      this_users_reviews: このユーザーのレビュー一覧
+      back_to_my_page: マイページへ戻る
     edit:
       title: プロフィール編集
     form:
@@ -79,11 +85,12 @@ ja:
       title: レビューを編集
     show:
       title: "%{shop}のレビュー"
-  my_reviews:
+  user_reviews:
     index:
-      title: 投稿したレビュー
+      title: "%{user}さんのレビュー一覧"
       back_to_mypage: マイページへ戻る
       no_reviews: まだレビューがありません
+      user_profile: このユーザーのプロフィール
   shop_tags:
     index:
       title: "%{shop}のタグ編集"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   get 'prefectures/:prefecture_id/areas', to: 'areas#index', as: :prefecture_areas
 
-  get 'shop_locations', to: 'shop_locations#index'
+  resources :shop_locations, only: :index
 
   resources :shops, only: %i[index show], shallow: true do
     resources :reviews
@@ -26,21 +26,24 @@ Rails.application.routes.draw do
     resources :favorites, only: :create
   end
 
-  resources :favorites, only: %i[index destroy]
-
-  get 'my_review', to: 'my_reviews#index'
-
-  get 'mypage', to: 'profiles#show'
-  resource :profile, only: %i[edit update]
-
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback' # for use with Github, Facebook
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
 
-  resources :users, only: :create
+  resources :users, only: :create do
+    resource :profile, only: :show
+  end
   resource :user, only: :destroy
-  get 'signup', to: 'users#new'
 
+  get 'users/:user_id/reviews', to: 'user_reviews#index', as: :user_reviews
+
+  resource :profile, only: %i[edit update]
+
+  get 'my_page', to: 'my_pages#index'
+
+  resources :favorites, only: %i[index destroy]
+
+  get 'signup', to: 'users#new'
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
# 変更後の構成

- マイページ
  - URI：`my_page`
  - コントローラ・アクション：`my_pages#index`
- プロフィール表示
  - URI：`users/:user_id/profile`
  - コントローラ・アクション：`user_profiles#show`
- プロフィール編集
  - URI：`profile/:id`
  - コントローラ・アクション：`profiles#edit` `profiles#update`
- 投稿したレビュー一覧
  - URI：`users/:user_id/reviews`
  - コントローラ・アクション：`user_reviews#index`

# ほか変更点

レビュー詳細の店舗名を押すと店舗詳細に、ユーザー名を押すとそのユーザーのプロフィールページに飛ぶように変更。

closes #209 