### PR TITLE
レスポンシブ対応（トップ、ユーザー登録、ログイン）

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
     <%= render 'shared/flash_messages' %>
 
     <div class="flex-grow">
-      <div class="container w-5/6 mx-auto max-w-screen-xl my-10">
+      <div class="container w-5/6 mx-auto max-w-screen-md my-10">
         <%= yield %>
       </div>
     </div>

--- a/app/views/reviews/_nice_buttons.html.erb
+++ b/app/views/reviews/_nice_buttons.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.nice?(review) %>
+<% if current_user&.nice?(review) %>
   <%= render 'reviews/unnice', review: review %>
 <% else %>
   <%= render 'reviews/nice', review: review %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,11 +1,11 @@
 <% content_for :title, t('.title') %>
 
-<div class="mx-auto md:w-2/3 w-full max-w-xs">
+<div class="mx-auto md:w-2/3 w-full max-w-sm">
   <h1 class="font-bold text-2xl text-center text-neutral mb-8">
     <%= t '.title' %>
   </h1>
 
-  <div class='text-center mb-6' ontouchstart="">
+  <div class='text-center mb-6'>
     <%= render 'shared/line_login_button' %>
   </div>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('.title') %>
 
-<div class="mx-auto md:w-2/3 w-full max-w-xs">
+<div class="mx-auto md:w-2/3 w-full max-w-sm">
   <h1 class="font-bold text-2xl text-center text-neutral mb-8">
     <%= t('.title') %>
   </h1>


### PR DESCRIPTION
# 主な変更点
- アプリ全体のコンテンツ最大横幅をタブレットサイズに変更（それ以上大きい画面の場合は両サイドが空白になる仕様）
- ユーザー登録・ログインページのコンテンツ最大横幅を1段階引き上げ

# ついでに修正した点
- ログインしていない状態で店舗一覧・詳細にアクセスするとエラーになるバグを修正

closes #211 