### PR TITLE
fix:レビュー一覧のコメント欄の「続きを読む」をリンクに修正、ロケール化

### DIFF
--- a/app/views/reviews/_review_summary.html.erb
+++ b/app/views/reviews/_review_summary.html.erb
@@ -44,7 +44,7 @@
 
       <div class="comment mt-5 p-2 rounded-lg bg-white/50">
         <%= truncate(simple_format(review.comment), length: 100, omission: '…', escape: false) do %>
-          <span class="underline italic text-xs inline-block">（続きを読む）</span>
+          <%= link_to t('.read_more'), review_path(review), class: 'underline italic text-xs inline-block' %>
         <% end %>
       </div>
 

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -88,6 +88,8 @@ ja:
       title: レビューを編集
     show:
       title: "%{shop}のレビュー"
+    review_summary:
+      read_more: （続きを読む）
   user_reviews:
     index:
       title: "%{user}さんのレビュー一覧"


### PR DESCRIPTION
closes #253 