### PR TITLE
店舗立地検索ページ経由でログイン・ログアウトするとフラッシュメッセージが表示されないバグを修正

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to shop_locations_path, success: t('.success')
+      redirect_back_or_to my_page_path, success: t('.success')
     else
       flash.now[:error] = t('.failure')
       render :new, status: :unprocessable_entity

--- a/app/javascript/get_current_location.js
+++ b/app/javascript/get_current_location.js
@@ -22,8 +22,11 @@ function geoFindMe() {
   if (!navigator.geolocation) {
     warning.textContent = "このブラウザーは位置情報に対応していません";
   } else {
-    searchIcon.remove();
-    buttonText.before(loadingSpinner);
+    const searchIcon = document.querySelector("#search-icon");
+    const loadingSpinner = document.createElement('span');
+    loadingSpinner.className = "loading loading-spinner";
+    loadingSpinner.id = "loading-spinner";
+    searchIcon.replaceWith(loadingSpinner);
     buttonText.textContent = "位置情報を取得中…";
     searchButton.classList.add("btn-disabled");
     navigator.geolocation.getCurrentPosition(success, error);
@@ -31,15 +34,19 @@ function geoFindMe() {
 }
 
 const searchButton = document.querySelector("#search-with-current-location");
-const searchIcon = document.querySelector("#search-icon");
-const loadingSpinner = document.createElement('span');
-loadingSpinner.className = "loading loading-spinner";
 const buttonText = document.querySelector("#button-text");
-
 searchButton.addEventListener("click", geoFindMe);
 
-window.addEventListener("pageshow", function(event) {
+window.addEventListener('pageshow', function(event) {
   if (event.persisted) {
-      window.location.reload();
+    const loadingSpinner = document.querySelector("#loading-spinner");
+    if (loadingSpinner) {
+      const searchIcon = document.createElement("i");
+      searchIcon.className = "fa-solid fa-magnifying-glass";
+      searchIcon.id = "search-icon";
+      loadingSpinner.replaceWith(searchIcon);
+      buttonText.textContent = "現在地から探す";
+      searchButton.classList.remove("btn-disabled");
+    }
   }
-});
+})

--- a/app/javascript/get_current_location.js
+++ b/app/javascript/get_current_location.js
@@ -49,4 +49,4 @@ window.addEventListener('pageshow', function(event) {
       searchButton.classList.remove("btn-disabled");
     }
   }
-})
+});

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,4 @@
 <div class="navbar bg-base-100 sticky top-0 z-10 shadow-xl">
-
   <div class="flex-1 px-2">
     <%= link_to root_path, class: 'btn btn-ghost p-0' do %>
       <%= image_tag 'logo_long_text_and_stars.png', class: 'h-12 rounded-md' %>

--- a/app/views/shop_locations/index.html.erb
+++ b/app/views/shop_locations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t('.title') %>
 <% content_for :javascript_includes do %>
-  <%= javascript_include_tag 'get_current_location', "data-turbo-track": "reload", type: "module" %>
+  <%= javascript_include_tag 'get_current_location', type: "module" %>
 <% end %>
 
 <div class="title mb-8">
@@ -12,13 +12,11 @@
 <div class="search flex flex-col gap-y-6">
   <div class="location text-center">
     <button id="search-with-current-location" class="btn btn-accent w-full max-w-md">
-      <span id="search-icon">
-        <i class="fa-solid fa-magnifying-glass"></i>
-      </span>
+      <i class="fa-solid fa-magnifying-glass" id="search-icon"></i>
       <span id="button-text">現在地から探す</span>
     </button>
     <p id="warning" class="text-rose-700 text-center"></p>
-    <%= form_with scope: :q, url: shops_url, method: :get, local: true, id: 'current-location-form' do |f| %>
+    <%= form_with scope: :q, url: shops_url, method: :get, local: true, data: { turbo: false }, id: 'current-location-form' do |f| %>
       <%= hidden_field_tag 'sort[key]', 'distance' %>
       <%= f.hidden_field :latitude %>
       <%= f.hidden_field :longitude %>
@@ -29,7 +27,7 @@
     <div class="heading text-lg text-center mb-2">
       <h2>フリーワードで探す</h2>
     </div>
-    <%= form_with scope: :q, url: shops_url, method: :get, local: true, class: 'flex justify-center' do |f| %>
+    <%= form_with scope: :q, url: shops_url, method: :get, local: true, data: { turbo: false }, class: 'flex justify-center' do |f| %>
       <%= hidden_field_tag 'sort[key]', 'id' %>
       <div class="join flex w-full max-w-md">
         <%= f.search_field :words, placeholder: '店名・住所', class: 'input input-bordered input-primary join-item grow' %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -15,7 +15,7 @@
         メールアドレスとパスワードでログイン
       </div>
 
-      <%= form_with url: login_url, local: true do |f| %>
+      <%= form_with url: login_url, local: true, data: { turbo: false } do |f| %>
         <div class="form-control">
           <%= f.label :email, class: 'label' %>
           <%= f.email_field :email, class: 'input input-bordered input-primary w-full max-w-xs' %>


### PR DESCRIPTION
# 問題の概要
ログイン後に店舗立地検索ページにリダイレクトした場合および店舗立地検索ページにいる状態でヘッダーメニューのリンクからログアウトした場合にフラッシュメッセージが表示されない。

# 原因
当該ページビューファイル内の`<%= javascript_include_tag 'get_current_location', data-turbo-track: "reload", type: "module" %>`というコード。`data-turbo-track: "reload"`によりページ全体がリロードされてしまっていた。

# 解決方法
問題のコードから`data-turbo-track: "reload"`を削除。
またJSコードについても、ブラウザバック時にボタンの表示をリセットするためのページ全体をリロードする処理が存在していたため、リロードではなくDOM操作で初期状態に戻す処理に変更。

# そのほかの変更
ログイン時のデフォルトリダイレクト先をマイページに変更。