### PR TITLE
ログイン中はアクセスできないページへアクセスした際の挙動を変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
-
   add_flash_types :success, :info, :warning, :error
 
   NUM_OF_REVIEWS_FOR_GOLD = 15
@@ -8,7 +7,7 @@ class ApplicationController < ActionController::Base
   NUM_OF_REVIEWS_FOR_BRONZE = 3
 
   def redirect_if_logged_in
-    redirect_to(shop_locations_path, error: t('defaults.flash_message.logged_in')) if logged_in?
+    redirect_to(my_page_path) if logged_in?
   end
 
   protected


### PR DESCRIPTION
"ログイン中はアクセスできません"というフラッシュメッセージの表示と店舗立地検索ページへのリダイレクトを行っていたが、フラッシュメッセージを削除しリダイレクトのみに変更。
`redirect_if_logged_in`メソッドからフラッシュメッセージの表示処理を削除した。

closes #260 