### PR TITLE
ユーザーネームが長いとログイン後ヘッダーのデザインが崩れる問題を修正

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,7 +1,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
 
-  validates :name, presence: true, length: { maximum: 20 }
+  validates :name, presence: true, length: { maximum: 15 }
   validates :gender, presence: true
   validates :age_group, presence: true
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -4,7 +4,7 @@
 
     <div class="form-control">
       <%= form.label :name, class: 'label' %>
-      <%= form.text_field :name, maxlength: 20, placeholder: t('.user_name_rule'), class: "input input-bordered input-primary w-full" %>
+      <%= form.text_field :name, maxlength: 15, placeholder: t('.user_name_rule'), class: "input input-bordered input-primary w-full" %>
     </div>
 
     <div class="form-control">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,7 +7,7 @@
 
   <div class="flex justify-end flex-1 px-2">
     <div class="flex items-center gap-x-2">
-      <%= link_to current_user.name, my_page_path, class: 'btn btn-ghost text-xs' %>
+      <%= link_to current_user.name, my_page_path, class: 'btn btn-ghost text-xs break-all max-w-28 md:max-w-none p-1' %>
       <details class="dropdown dropdown-end">
         <summary class="btn btn-ghost rounded-btn">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -80,7 +80,7 @@ ja:
     edit:
       title: プロフィール編集
     form:
-      user_name_rule: 20文字以内
+      user_name_rule: 15文字以内
   reviews:
     new:
       title: レビュー投稿

--- a/db/migrate/20240706091618_change_limit_name_of_profile.rb
+++ b/db/migrate/20240706091618_change_limit_name_of_profile.rb
@@ -1,0 +1,5 @@
+class ChangeLimitNameOfProfile < ActiveRecord::Migration[7.0]
+  def change
+    change_column :profiles, :name, :string, null: false, limit: 15, default: '名無しのヒトカラー'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,137 +10,137 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_06_091618) do
+ActiveRecord::Schema[7.0].define(version: 20_240_706_091_618) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "areas", force: :cascade do |t|
-    t.bigint "prefecture_id", null: false
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["prefecture_id"], name: "index_areas_on_prefecture_id"
+  create_table 'areas', force: :cascade do |t|
+    t.bigint 'prefecture_id', null: false
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['prefecture_id'], name: 'index_areas_on_prefecture_id'
   end
 
-  create_table "authentications", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.string "provider", null: false
-    t.string "uid", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  create_table 'authentications', force: :cascade do |t|
+    t.integer 'user_id', null: false
+    t.string 'provider', null: false
+    t.string 'uid', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
   end
 
-  create_table "favorites", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "shop_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["shop_id"], name: "index_favorites_on_shop_id"
-    t.index ["user_id", "shop_id"], name: "index_favorites_on_user_id_and_shop_id", unique: true
-    t.index ["user_id"], name: "index_favorites_on_user_id"
+  create_table 'favorites', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'shop_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['shop_id'], name: 'index_favorites_on_shop_id'
+    t.index %w[user_id shop_id], name: 'index_favorites_on_user_id_and_shop_id', unique: true
+    t.index ['user_id'], name: 'index_favorites_on_user_id'
   end
 
-  create_table "nices", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "review_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["review_id"], name: "index_nices_on_review_id"
-    t.index ["user_id", "review_id"], name: "index_nices_on_user_id_and_review_id", unique: true
-    t.index ["user_id"], name: "index_nices_on_user_id"
+  create_table 'nices', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'review_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['review_id'], name: 'index_nices_on_review_id'
+    t.index %w[user_id review_id], name: 'index_nices_on_user_id_and_review_id', unique: true
+    t.index ['user_id'], name: 'index_nices_on_user_id'
   end
 
-  create_table "prefectures", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_prefectures_on_name", unique: true
+  create_table 'prefectures', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['name'], name: 'index_prefectures_on_name', unique: true
   end
 
-  create_table "profiles", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "name", limit: 15, default: "名無しのヒトカラー", null: false
-    t.integer "gender", default: 0, null: false
-    t.integer "age_group", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_profiles_on_user_id"
+  create_table 'profiles', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.string 'name', limit: 15, default: '名無しのヒトカラー', null: false
+    t.integer 'gender', default: 0, null: false
+    t.integer 'age_group', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_profiles_on_user_id'
   end
 
-  create_table "reviews", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "shop_id", null: false
-    t.integer "minimal_interaction", default: 3, null: false
-    t.integer "equipment_customization", default: 3, null: false
-    t.integer "solo_friendly", default: 3, null: false
-    t.text "comment"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["shop_id"], name: "index_reviews_on_shop_id"
-    t.index ["user_id", "shop_id"], name: "index_reviews_on_user_id_and_shop_id", unique: true
-    t.index ["user_id"], name: "index_reviews_on_user_id"
+  create_table 'reviews', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'shop_id', null: false
+    t.integer 'minimal_interaction', default: 3, null: false
+    t.integer 'equipment_customization', default: 3, null: false
+    t.integer 'solo_friendly', default: 3, null: false
+    t.text 'comment'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['shop_id'], name: 'index_reviews_on_shop_id'
+    t.index %w[user_id shop_id], name: 'index_reviews_on_user_id_and_shop_id', unique: true
+    t.index ['user_id'], name: 'index_reviews_on_user_id'
   end
 
-  create_table "shop_tags", force: :cascade do |t|
-    t.bigint "shop_id", null: false
-    t.bigint "tag_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["shop_id", "tag_id"], name: "index_shop_tags_on_shop_id_and_tag_id", unique: true
-    t.index ["shop_id"], name: "index_shop_tags_on_shop_id"
-    t.index ["tag_id"], name: "index_shop_tags_on_tag_id"
+  create_table 'shop_tags', force: :cascade do |t|
+    t.bigint 'shop_id', null: false
+    t.bigint 'tag_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[shop_id tag_id], name: 'index_shop_tags_on_shop_id_and_tag_id', unique: true
+    t.index ['shop_id'], name: 'index_shop_tags_on_shop_id'
+    t.index ['tag_id'], name: 'index_shop_tags_on_tag_id'
   end
 
-  create_table "shops", force: :cascade do |t|
-    t.bigint "area_id", null: false
-    t.string "name", null: false
-    t.string "address", null: false
-    t.string "phone_number"
-    t.string "url"
-    t.string "opening_hours"
-    t.decimal "latitude", precision: 9, scale: 6, null: false
-    t.decimal "longitude", precision: 9, scale: 6, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "int_average", default: 0, null: false
-    t.integer "eqcust_average", default: 0, null: false
-    t.integer "sofr_average", default: 0, null: false
-    t.index ["area_id"], name: "index_shops_on_area_id"
-    t.index ["name", "address"], name: "index_shops_on_name_and_address", unique: true
+  create_table 'shops', force: :cascade do |t|
+    t.bigint 'area_id', null: false
+    t.string 'name', null: false
+    t.string 'address', null: false
+    t.string 'phone_number'
+    t.string 'url'
+    t.string 'opening_hours'
+    t.decimal 'latitude', precision: 9, scale: 6, null: false
+    t.decimal 'longitude', precision: 9, scale: 6, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'int_average', default: 0, null: false
+    t.integer 'eqcust_average', default: 0, null: false
+    t.integer 'sofr_average', default: 0, null: false
+    t.index ['area_id'], name: 'index_shops_on_area_id'
+    t.index %w[name address], name: 'index_shops_on_name_and_address', unique: true
   end
 
-  create_table "tags", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'tags', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email"
-    t.string "crypted_password"
-    t.string "salt"
-    t.integer "role", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_token_expires_at"
-    t.datetime "reset_password_email_sent_at"
-    t.integer "access_count_to_reset_password_page", default: 0
-    t.integer "rank", default: 0, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
+  create_table 'users', force: :cascade do |t|
+    t.string 'email'
+    t.string 'crypted_password'
+    t.string 'salt'
+    t.integer 'role', default: 0, null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_token_expires_at'
+    t.datetime 'reset_password_email_sent_at'
+    t.integer 'access_count_to_reset_password_page', default: 0
+    t.integer 'rank', default: 0, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token'
   end
 
-  add_foreign_key "areas", "prefectures"
-  add_foreign_key "favorites", "shops"
-  add_foreign_key "favorites", "users"
-  add_foreign_key "nices", "reviews"
-  add_foreign_key "nices", "users"
-  add_foreign_key "profiles", "users"
-  add_foreign_key "reviews", "shops"
-  add_foreign_key "reviews", "users"
-  add_foreign_key "shop_tags", "shops"
-  add_foreign_key "shop_tags", "tags"
-  add_foreign_key "shops", "areas"
+  add_foreign_key 'areas', 'prefectures'
+  add_foreign_key 'favorites', 'shops'
+  add_foreign_key 'favorites', 'users'
+  add_foreign_key 'nices', 'reviews'
+  add_foreign_key 'nices', 'users'
+  add_foreign_key 'profiles', 'users'
+  add_foreign_key 'reviews', 'shops'
+  add_foreign_key 'reviews', 'users'
+  add_foreign_key 'shop_tags', 'shops'
+  add_foreign_key 'shop_tags', 'tags'
+  add_foreign_key 'shops', 'areas'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,137 +10,137 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_240_609_100_527) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_06_091618) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'areas', force: :cascade do |t|
-    t.bigint 'prefecture_id', null: false
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['prefecture_id'], name: 'index_areas_on_prefecture_id'
+  create_table "areas", force: :cascade do |t|
+    t.bigint "prefecture_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prefecture_id"], name: "index_areas_on_prefecture_id"
   end
 
-  create_table 'authentications', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.string 'provider', null: false
-    t.string 'uid', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[provider uid], name: 'index_authentications_on_provider_and_uid'
+  create_table "authentications", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 
-  create_table 'favorites', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'shop_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['shop_id'], name: 'index_favorites_on_shop_id'
-    t.index %w[user_id shop_id], name: 'index_favorites_on_user_id_and_shop_id', unique: true
-    t.index ['user_id'], name: 'index_favorites_on_user_id'
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "shop_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shop_id"], name: "index_favorites_on_shop_id"
+    t.index ["user_id", "shop_id"], name: "index_favorites_on_user_id_and_shop_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
-  create_table 'nices', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'review_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['review_id'], name: 'index_nices_on_review_id'
-    t.index %w[user_id review_id], name: 'index_nices_on_user_id_and_review_id', unique: true
-    t.index ['user_id'], name: 'index_nices_on_user_id'
+  create_table "nices", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "review_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_id"], name: "index_nices_on_review_id"
+    t.index ["user_id", "review_id"], name: "index_nices_on_user_id_and_review_id", unique: true
+    t.index ["user_id"], name: "index_nices_on_user_id"
   end
 
-  create_table 'prefectures', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['name'], name: 'index_prefectures_on_name', unique: true
+  create_table "prefectures", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_prefectures_on_name", unique: true
   end
 
-  create_table 'profiles', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.string 'name', limit: 30, default: '名無しのヒトカラー', null: false
-    t.integer 'gender', default: 0, null: false
-    t.integer 'age_group', default: 0, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_profiles_on_user_id'
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", limit: 15, default: "名無しのヒトカラー", null: false
+    t.integer "gender", default: 0, null: false
+    t.integer "age_group", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
-  create_table 'reviews', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'shop_id', null: false
-    t.integer 'minimal_interaction', default: 3, null: false
-    t.integer 'equipment_customization', default: 3, null: false
-    t.integer 'solo_friendly', default: 3, null: false
-    t.text 'comment'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['shop_id'], name: 'index_reviews_on_shop_id'
-    t.index %w[user_id shop_id], name: 'index_reviews_on_user_id_and_shop_id', unique: true
-    t.index ['user_id'], name: 'index_reviews_on_user_id'
+  create_table "reviews", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "shop_id", null: false
+    t.integer "minimal_interaction", default: 3, null: false
+    t.integer "equipment_customization", default: 3, null: false
+    t.integer "solo_friendly", default: 3, null: false
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shop_id"], name: "index_reviews_on_shop_id"
+    t.index ["user_id", "shop_id"], name: "index_reviews_on_user_id_and_shop_id", unique: true
+    t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
-  create_table 'shop_tags', force: :cascade do |t|
-    t.bigint 'shop_id', null: false
-    t.bigint 'tag_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[shop_id tag_id], name: 'index_shop_tags_on_shop_id_and_tag_id', unique: true
-    t.index ['shop_id'], name: 'index_shop_tags_on_shop_id'
-    t.index ['tag_id'], name: 'index_shop_tags_on_tag_id'
+  create_table "shop_tags", force: :cascade do |t|
+    t.bigint "shop_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shop_id", "tag_id"], name: "index_shop_tags_on_shop_id_and_tag_id", unique: true
+    t.index ["shop_id"], name: "index_shop_tags_on_shop_id"
+    t.index ["tag_id"], name: "index_shop_tags_on_tag_id"
   end
 
-  create_table 'shops', force: :cascade do |t|
-    t.bigint 'area_id', null: false
-    t.string 'name', null: false
-    t.string 'address', null: false
-    t.string 'phone_number'
-    t.string 'url'
-    t.string 'opening_hours'
-    t.decimal 'latitude', precision: 9, scale: 6, null: false
-    t.decimal 'longitude', precision: 9, scale: 6, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'int_average', default: 0, null: false
-    t.integer 'eqcust_average', default: 0, null: false
-    t.integer 'sofr_average', default: 0, null: false
-    t.index ['area_id'], name: 'index_shops_on_area_id'
-    t.index %w[name address], name: 'index_shops_on_name_and_address', unique: true
+  create_table "shops", force: :cascade do |t|
+    t.bigint "area_id", null: false
+    t.string "name", null: false
+    t.string "address", null: false
+    t.string "phone_number"
+    t.string "url"
+    t.string "opening_hours"
+    t.decimal "latitude", precision: 9, scale: 6, null: false
+    t.decimal "longitude", precision: 9, scale: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "int_average", default: 0, null: false
+    t.integer "eqcust_average", default: 0, null: false
+    t.integer "sofr_average", default: 0, null: false
+    t.index ["area_id"], name: "index_shops_on_area_id"
+    t.index ["name", "address"], name: "index_shops_on_name_and_address", unique: true
   end
 
-  create_table 'tags', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'email'
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.integer 'role', default: 0, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_token_expires_at'
-    t.datetime 'reset_password_email_sent_at'
-    t.integer 'access_count_to_reset_password_page', default: 0
-    t.integer 'rank', default: 0, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token'
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "crypted_password"
+    t.string "salt"
+    t.integer "role", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.integer "access_count_to_reset_password_page", default: 0
+    t.integer "rank", default: 0, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
-  add_foreign_key 'areas', 'prefectures'
-  add_foreign_key 'favorites', 'shops'
-  add_foreign_key 'favorites', 'users'
-  add_foreign_key 'nices', 'reviews'
-  add_foreign_key 'nices', 'users'
-  add_foreign_key 'profiles', 'users'
-  add_foreign_key 'reviews', 'shops'
-  add_foreign_key 'reviews', 'users'
-  add_foreign_key 'shop_tags', 'shops'
-  add_foreign_key 'shop_tags', 'tags'
-  add_foreign_key 'shops', 'areas'
+  add_foreign_key "areas", "prefectures"
+  add_foreign_key "favorites", "shops"
+  add_foreign_key "favorites", "users"
+  add_foreign_key "nices", "reviews"
+  add_foreign_key "nices", "users"
+  add_foreign_key "profiles", "users"
+  add_foreign_key "reviews", "shops"
+  add_foreign_key "reviews", "users"
+  add_foreign_key "shop_tags", "shops"
+  add_foreign_key "shop_tags", "tags"
+  add_foreign_key "shops", "areas"
 end


### PR DESCRIPTION
- ユーザーネームの字数上限を20→15に変更
- ログイン後ヘッダーのユーザーネームボタンに最大横幅を設定